### PR TITLE
Back to cloud latest, fix README, error in POM

### DIFF
--- a/java/managed-vms/README.md
+++ b/java/managed-vms/README.md
@@ -3,10 +3,6 @@
 A simple Hello World app that takes your an opaque user ID and uses it as a key to count how often you've
 visited.  The app also provides a simple JSON REST client that enables the GET, POST, and DELETE Verbs.
 
-# IMPORTANT – TEMPORARY
-# Roll back to this version of the SDK
-`gcloud config set --scope=installation component_manager/fixed_sdk_version 0.9.55`
-
 `gcloud components update`
 
 ### IMPORTANT - The java samples require that the hbase-bigtable jar be installed in your local maven repository manually:
@@ -53,7 +49,7 @@ Download the [Jar](https://storage.googleapis.com/cloud-bigtable/jars/bigtable-h
 
  `gcloud auth login`
  
-1. Follow the instructions (?? WHERE ??) to enable `hbase shell`
+1. Follow the [instructions to enable `hbase shell`](https://cloud.google.com/bigtable/docs/hbase-shell-quickstart)
 
 1. Launch `hbase shell`
 

--- a/java/managed-vms/helloworld/pom.xml
+++ b/java/managed-vms/helloworld/pom.xml
@@ -27,9 +27,9 @@
   <artifactId>helloworld</artifactId>
 
   <properties>
-    <projectid>PROJECT_ID_HERE</projectid>
+    <projectid>YOUR_PROJECT_ID_HERE</projectid>
     <appengine.target.version>1.9.19</appengine.target.version>
-    <gcloud.plugin.version>0.9.57.v20150425</gcloud.plugin.version>
+    <gcloud.plugin.version>0.9.58.v20150505</gcloud.plugin.version>
     <compileSource>1.7</compileSource>
 
     <bigtable.version>0.1.5</bigtable.version>

--- a/java/managed-vms/helloworld/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/java/managed-vms/helloworld/src/main/webapp/WEB-INF/appengine-web.xml
@@ -33,7 +33,7 @@
     <automatic-scaling>
       <min-num-instances>1</min-num-instances>
       <max-num-instances>20</max-num-instances>
-      <cool-down-period-sec>330</cool-down-period>
+      <cool-down-period-sec>330</cool-down-period-sec>
       <cpu-utilization>
         <target-utilization>0.8</target-utilization>
       </cpu-utilization>


### PR DESCRIPTION
1. No longer need rolled back cloud command
2. Fix README
3. Latest mvn gcloud tool
4. Stupid error in pom.xml - fixed.