### PR TITLE
More updates per Ludo and fixing my stupidity.

### DIFF
--- a/java/managed-vms/README.md
+++ b/java/managed-vms/README.md
@@ -90,7 +90,9 @@ Download the [Jar](https://storage.googleapis.com/cloud-bigtable/jars/bigtable-h
 
 ### Deploying as a managed VM app
 
-1. Set the `project_ID` in `pom.xml`
+1. If you haven't already done so, set your project in the gcloud tool.
+
+  `gcloud config set project PROJECT_ID`
 
 1. Set `PROJECT_ID`, `CLUSTER_UNIQUE_ID`, and `Zone` (if necessary) in `src/main/java/com/example/bigtable/managedvms/BigtableHelper.java`
 

--- a/java/managed-vms/helloworld/pom.xml
+++ b/java/managed-vms/helloworld/pom.xml
@@ -27,7 +27,6 @@
   <artifactId>helloworld</artifactId>
 
   <properties>
-    <projectid>YOUR_PROJECT_ID_HERE</projectid>
     <appengine.target.version>1.9.19</appengine.target.version>
     <gcloud.plugin.version>0.9.58.v20150505</gcloud.plugin.version>
     <compileSource>1.7</compileSource>
@@ -543,7 +542,7 @@
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>${gcloud.plugin.version}</version>
         <configuration>
-          <gcloud_project>${projectid}</gcloud_project>
+          <set_default>true</set_default>
         </configuration>
       </plugin>
 

--- a/java/managed-vms/helloworld/src/main/java/com.example.cloud.bigtable.helloworld/BigtableHelper.java
+++ b/java/managed-vms/helloworld/src/main/java/com.example.cloud.bigtable.helloworld/BigtableHelper.java
@@ -39,6 +39,7 @@ public class BigtableHelper implements ServletContextListener {
  **/
   private static final String PROJECT_ID = "PROJECT_ID_HERE";
   private static final String CLUSTER_ID = "CLUSTER_UNIQUE_ID";
+
   private static final String ZONE = "us-central1-b";
 
 // The initial connection to Cloud Bigtable is an expensive operation -- We cache this Connection

--- a/java/managed-vms/helloworld/src/main/webapp/Dockerfile
+++ b/java/managed-vms/helloworld/src/main/webapp/Dockerfile
@@ -1,5 +1,6 @@
 FROM gae-bt-v02
 
-# ENV GOOGLE_APPLICATION_CREDENTIALS=
+# The below line is only needed if you want to "mvn gcloud:run" on your local computer
+# ENV GOOGLE_APPLICATION_CREDENTIALS=/app/WEB-INF/YOUR_KEY_FILE.json
 
 ADD . /app

--- a/java/managed-vms/helloworld/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/java/managed-vms/helloworld/src/main/webapp/WEB-INF/appengine-web.xml
@@ -16,16 +16,10 @@
  -->
  
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-
-  <application>${projectid}</application>
   
-    <version>hellojava</version>
     <threadsafe>true</threadsafe>
     <vm>true</vm>
 
-<!-- 
-  Requesting bigtable.data scope is very important.
- -->
     <beta-settings>
       <setting name="service_account_scopes" value="https://www.googleapis.com/auth/cloud-platform, https://www.googleapis.com/auth/devstorage.full_control" />
     </beta-settings>
@@ -35,7 +29,7 @@
       <max-num-instances>20</max-num-instances>
       <cool-down-period-sec>330</cool-down-period-sec>
       <cpu-utilization>
-        <target-utilization>0.8</target-utilization>
+        <target-utilization>0.5</target-utilization>
       </cpu-utilization>
     </automatic-scaling>
   

--- a/java/managed-vms/helloworld/src/main/webapp/WEB-INF/web.xml
+++ b/java/managed-vms/helloworld/src/main/webapp/WEB-INF/web.xml
@@ -35,8 +35,7 @@
 
   <servlet>
     <servlet-name>hello</servlet-name>
-    <servlet-class>com.example.bigtable.managedvms.HelloServlet</servlet-class>
-    <load-on-startup>1</load-on-startup>
+    <servlet-class>com.example.cloud.bigtable.helloworld.HelloServlet</servlet-class>
   </servlet>
   <servlet-mapping>
     <servlet-name>hello</servlet-name>
@@ -45,7 +44,7 @@
 
   <servlet>
     <servlet-name>json</servlet-name>
-    <servlet-class>com.example.bigtable.managedvms.JsonServlet</servlet-class>
+    <servlet-class>com.example.cloud.bigtable.helloworld.JsonServlet</servlet-class>
   </servlet>
   <servlet-mapping>
     <servlet-name>json</servlet-name>
@@ -53,7 +52,7 @@
   </servlet-mapping>
 
   <listener>
-    <listener-class>com.example.bigtable.managedvms.BigtableHelper</listener-class>
+    <listener-class>com.example.cloud.bigtable.helloworld.BigtableHelper</listener-class>
   </listener>
 
 <!-- 


### PR DESCRIPTION
1. Instead of setting project_ID & version in the pom.xml, let gcloud do it
2. Fix package names in web.xml (My Bad .. some files didn’t get copied)
3. Get rid of projectID & version from appengine-web.xml
4. Get rid of old comment and set target utilization to 0.5 - another
change that didn’t get migrated.
5. Add comment for GOOGLE_APPLICATION_CREDENTIALS
6. Add set_default key to mvn