### PR TITLE
Remove obsolete configuration properties

### DIFF
--- a/java/jetty-managed-vm/bigtable-hello/src/main/java/com/example/cloud/bigtable/helloworld/BigtableHelper.java
+++ b/java/jetty-managed-vm/bigtable-hello/src/main/java/com/example/cloud/bigtable/helloworld/BigtableHelper.java
@@ -52,8 +52,6 @@ public class BigtableHelper implements ServletContextListener {
     c.setClass("hbase.client.connection.impl",
         com.google.cloud.bigtable.hbase1_1.BigtableConnection.class,
         org.apache.hadoop.hbase.client.Connection.class);   // Required for Cloud Bigtable
-    c.set("google.bigtable.endpoint.host", "bigtable.googleapis.com");
-    c.set("google.bigtable.admin.endpoint.host", "bigtabletableadmin.googleapis.com");
 
     if (ZONE == null) ZONE = "us-central1-b"; // default
     if (PROJECT_ID == null || CLUSTER_ID == null ) {

--- a/java/managed-vm-gae/gae-bigtable-hello/src/main/java/com/example/cloud/bigtable/helloworld/BigtableHelper.java
+++ b/java/managed-vm-gae/gae-bigtable-hello/src/main/java/com/example/cloud/bigtable/helloworld/BigtableHelper.java
@@ -52,8 +52,6 @@ public class BigtableHelper implements ServletContextListener {
     c.setClass("hbase.client.connection.impl",
         com.google.cloud.bigtable.hbase1_1.BigtableConnection.class,
         org.apache.hadoop.hbase.client.Connection.class);   // Required for Cloud Bigtable
-    c.set("google.bigtable.endpoint.host", "bigtable.googleapis.com");
-    c.set("google.bigtable.admin.endpoint.host", "bigtabletableadmin.googleapis.com");
 
     if (ZONE == null) ZONE = "us-central1-b"; // default
     if (PROJECT_ID == null || CLUSTER_ID == null ) {

--- a/java/simple-cli/README.md
+++ b/java/simple-cli/README.md
@@ -43,14 +43,6 @@ enter the project id and info for the service account in the locations shown.
         <name>hbase.client.connection.impl</name>
         <value>com.google.cloud.bigtable.hbase1_1.BigtableConnection</value>
       </property>
-      <property>
-        <name>google.bigtable.endpoint.host</name>
-        <value>bigtable.googleapis.com</value>
-      </property>
-      <property>
-        <name>google.bigtable.admin.endpoint.host</name>
-        <value>table-admin-bigtable.googleapis.com</value>
-      </property>
     </configuration>
 
 ## Build

--- a/java/simple-cli/src/main/resources/hbase-site.xml
+++ b/java/simple-cli/src/main/resources/hbase-site.xml
@@ -35,12 +35,4 @@
     <name>hbase.client.connection.impl</name>
     <value>com.google.cloud.bigtable.hbase1_1.BigtableConnection</value>
   </property>
-  <property>
-    <name>google.bigtable.endpoint.host</name>
-    <value>bigtable.googleapis.com</value>
-  </property>
-  <property>
-    <name>google.bigtable.admin.endpoint.host</name>
-    <value>bigtabletableadmin.googleapis.com</value>
-  </property>
 </configuration>

--- a/java/storm/README.md
+++ b/java/storm/README.md
@@ -56,14 +56,6 @@ enter the project id and info for the service account in the locations shown.
         <name>hbase.client.connection.impl</name>
         <value>com.google.cloud.bigtable.hbase1_1.BigtableConnection</value>
       </property>
-      <property>
-        <name>google.bigtable.endpoint.host</name>
-        <value>bigtable.googleapis.com</value>
-      </property>
-      <property>
-        <name>google.bigtable.admin.endpoint.host</name>
-        <value>table-admin-bigtable.googleapis.com</value>
-      </property>
     </configuration>
 
 ## Build

--- a/java/storm/src/main/resources/hbase-site.xml
+++ b/java/storm/src/main/resources/hbase-site.xml
@@ -42,12 +42,4 @@
     <name>hbase.client.connection.impl</name>
     <value>com.google.cloud.bigtable.hbase1_1.BigtableConnection</value>
   </property>
-  <property>
-    <name>google.bigtable.endpoint.host</name>
-    <value>bigtable.googleapis.com</value>
-  </property>
-  <property>
-    <name>google.bigtable.admin.endpoint.host</name>
-    <value>bigtabletableadmin.googleapis.com</value>
-  </property>
 </configuration>

--- a/quickstart/create-hbase-site
+++ b/quickstart/create-hbase-site
@@ -58,10 +58,6 @@ echo "  <property><name>google.bigtable.cluster.name</name><value>${_clusterID}<
 echo "  <property><name>google.bigtable.zone.name</name><value>${_zone}</value></property>" >>hbase-site.xml
 echo "" >>hbase-site.xml
 echo "  <property>" >>hbase-site.xml
-echo "    <name>google.bigtable.endpoint.host</name>" >>hbase-site.xml
-echo "    <value>bigtable.googleapis.com</value>" >>hbase-site.xml
-echo "  </property>" >>hbase-site.xml
-echo "  <property>" >>hbase-site.xml
 echo "     <name>hbase.client.connection.impl</name>" >>hbase-site.xml
 echo "     <value>com.google.cloud.bigtable.hbase1_0.BigtableConnection</value>" >>hbase-site.xml
 echo "  </property>" >>hbase-site.xml


### PR DESCRIPTION
The config properties `google.bigtable.endpoint.host` and `google.bigtable.admin.endpoint.host` are now automatically set by default, so it should be safe to remove them from the code samples.

This pull request supersedes #54.