### PR TITLE
Remove the key.json file

### DIFF
--- a/java/wordcount-mapreduce/README.md
+++ b/java/wordcount-mapreduce/README.md
@@ -15,10 +15,6 @@ In order to run this mapreduce sample please follow the Cloud Bigtable [Getting 
     * Cloud Bigtable API
     * Cloud Bigtable Table Admin API
     * Google Cloud Dataproc API
-  * Create a Service Account (APIs & auth > Credentials)
-    **(This step is temporary)**
-    * Click on  Add credentials > Service Account > JSON > Create
-    * Copy the JSON file to the examples main directory and rename as **`key.json`**
   * Create a [Cloud Bigtable Cluster](https://cloud.google.com/bigtable/docs/creating-cluster)
   * Development Environment Setup
     * Install [Google Cloud SDK](https://cloud.google.com/sdk/)

--- a/java/wordcount-mapreduce/dp-mr-hb-init.sh
+++ b/java/wordcount-mapreduce/dp-mr-hb-init.sh
@@ -24,7 +24,6 @@ BUCKET=$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)
 # gcloud -q components update alpha beta
 
 echo "Copying files from Bucket"
-gsutil -q cp gs://${BUCKET}/key.json /key.json
 gsutil -q cp gs://${BUCKET}/hbase-site.xml /etc/hadoop/conf/
 gsutil -q cp gs://${BUCKET}/hbase-site.xml /etc/hbase/conf/
 

--- a/java/wordcount-mapreduce/pom.xml
+++ b/java/wordcount-mapreduce/pom.xml
@@ -94,7 +94,6 @@
               <argument>cp</argument>
               <argument>-r</argument>
               <argument>dp-mr-hb-init.sh</argument>
-              <argument>key.json</argument>
               <argument>${settings.localRepository}/com/google/cloud/bigtable/bigtable-hbase-${hbase.if}/${bigtable.version}/bigtable-hbase-${hbase.if}-${bigtable.version}.jar</argument>
               <argument>${settings.localRepository}/com/google/cloud/bigtable/bigtable-hbase-mapreduce/${bigtable.version}/bigtable-hbase-mapreduce-${bigtable.version}.jar</argument>
               <argument>target/${project.artifactId}-${project.version}/WEB-INF/classes/hbase-site.xml</argument>

--- a/java/wordcount-mapreduce/src/main/resources/hbase-site.xml
+++ b/java/wordcount-mapreduce/src/main/resources/hbase-site.xml
@@ -24,7 +24,6 @@
   <property><name>google.bigtable.project.id</name><value>${bigtable.projectID}</value></property>
   <property><name>google.bigtable.cluster.name</name><value>${bigtable.clusterID}</value></property>
   <property><name>google.bigtable.zone.name</name><value>${bigtable.zone}</value></property>
-  <property><name>google.bigtable.auth.json.keyfile</name><value>/key.json</value></property>
   <property>
     <name>hbase.client.connection.impl</name>
     <value>com.google.cloud.bigtable.hbase1_0.BigtableConnection</value>


### PR DESCRIPTION
No longer required - clusters have Cloud Bigtable enabled by default
now.