### PR TITLE
Updating admin.rb

### DIFF
--- a/quickstart/thirdparty/ruby/hbase/admin.rb
+++ b/quickstart/thirdparty/ruby/hbase/admin.rb
@@ -45,7 +45,7 @@ module Hbase
     #----------------------------------------------------------------------------------------------
     # Returns a list of tables in hbase
     def list(regex = ".*")
-      @admin.listTables(regex).map { |t| t.getNameAsString }
+      @admin.listTableNames(regex).map { |t| t.getNameAsString }
     end
 
     #----------------------------------------------------------------------------------------------

--- a/quickstart/thirdparty/ruby/hbase/admin.rb
+++ b/quickstart/thirdparty/ruby/hbase/admin.rb
@@ -45,7 +45,7 @@ module Hbase
     #----------------------------------------------------------------------------------------------
     # Returns a list of tables in hbase
     def list(regex = ".*")
-      @admin.listTableNames(regex).map { |t| t.getNameAsString }
+      @admin.listTableNames(regex).map { |t| t.getNameAsString }    # SD/LV3 Google Change
     end
 
     #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
The quickstart fails to 'list' on go generated tables.  Using listTableNames() instead of listTables() corrects that problem and is more efficient to boot.