### PR TITLE
Increase quick start size

### DIFF
--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -138,7 +138,7 @@
         <configuration>
           <executable>java</executable>
           <arguments>
-            <argument>-Xms256m</argument>
+            <argument>-Xms384m</argument>
             <argument>-Xmx2048m</argument>
             <argument>-XX:+UseConcMarkSweepGC</argument>
             <argument>-Dhbase.ruby.sources=thirdparty/ruby</argument>


### PR DESCRIPTION
We need a bit more memory now that we use BoringSSL -- Fixes hang on Cloud Shell
@sduskis FYI