### PR TITLE
App Engine - SSL - Thrift Gateway - Cloud Bigtable

### DIFF
--- a/python/thrift/appengine-ssl-gateway/README.md
+++ b/python/thrift/appengine-ssl-gateway/README.md
@@ -1,0 +1,296 @@
+# Connecting from Google App Engine to Google Cloud Bigtable
+
+It's easy to deploy a Thrift gateway cluster on Google Compute Engine that
+proxies requests to the Cloud Bigtable API.
+
+Here are step by step instructions for starting a Cloud Bigtable cluster and
+building and deploying a Thrift server on Compute Engine.
+
+**Requirements**
+
+Your system should have the following installed:
+
+* `gcloud` and `gsutil`, both provided by [Google Cloud
+  SDK](https://cloud.google.com/sdk)
+* `make`
+
+**Note:** all `make` commands below silence the actual commands being run to
+decrease the noise, so you will only see their output. If you'd like to see
+underlying commands being executed for debugging or to learn what's going on
+behind the scenes, run each `make` command below as:
+
+    $ make VERBOSE=1 <target>
+
+**Table of contents**
+
+1. [Create the Bigtable cluster](#create-bigtable-cluster)
+1. [Create a shared certificate](#create-shared-certificate)
+1. [Build the HBase Thrift gateway Docker
+   container](#build-thrift-gateway-container)
+1. [Deploy the Thrift gateway cluster on Google Compute
+   Engine](#deploy-thrift-gateway-cluster)
+1. [Connect from App Engine to the Thrift
+   gateway](#connect-appengine-to-thrift-gateway)
+1. (optional) [Troubleshooting](#troubleshooting)
+
+<a name="create-bigtable-cluster"></a>
+## Create the Bigtable cluster
+
+First, [enable the Bigtable APIs][bigtable-apis] on your project.
+
+Next, update `gcloud` to make sure we have the latest version:
+
+    $ gcloud components update
+
+Then, create the cluster:
+
+    $ export PROJECT_ID=[my-project]
+    $ export ZONE=[my-zone]
+    $ export CLUSTER_ID=[my-cluster]
+    $ gcloud alpha bigtable clusters create $CLUSTER_ID \
+          --project $PROJECT_ID --zone $ZONE --nodes 3 --description "My cluster"
+
+These environment variables will be used in later stages, so be sure to set them
+in your environment.
+
+  [create-cluster]: https://cloud.google.com/bigtable/docs/creating-cluster
+  [bigtable-apis]: https://console.cloud.google.com/flows/enableapi?apiid=bigtable,bigtabletableadmin
+
+<a name="create-shared-certificate"></a>
+## Create a shared certificate
+
+In order to secure the Thrift gateway from unauthorized access, we need to
+generate a private key which will be shared by the clients and Thrift server.
+This command will create the file `stunnel.pem` which will be the shared key:
+
+    $ cd thrift-gateway
+    $ make ssl-key
+
+Now we want to copy it to a Google Cloud Storage bucket so it can be accessed
+securely by the Thrift servers:
+
+    $ export BUCKET=<my-bucket-name>
+    $ make copy-ssl-key-to-gcs
+
+If that bucket doesn't already exist, this command will create it. Bucket names
+exist in a global namespace, so it's possible that someone has already created a
+bucket by that name and thus it will be unavailable for your use. In that case,
+you'll have to choose another name for your bucket.
+
+One easy approach for naming your bucket is to use your project name:
+
+    $ export BUCKET=$PROJECT_ID
+    $ make copy-ssl-key-to-gcs
+
+**Note:** Google Cloud Storage cannot have `:` in the name, so if you have a
+domain-scoped project whose id is of the form `example.com:my-project-id`
+you'll need to select a Google Cloud Storage bucket that does not include a `:`.
+
+<a name="build-thrift-gateway-container"></a>
+## Build the HBase Thrift gateway Docker container
+
+You can build the container locally on your machine and upload it to Google
+Container Registry, or you can deploy a Google Compute Engine VM and build
+there, which may be easier if Docker is not already installed on your local
+workstation.
+
+### (optional) Deploy a Google Compute Engine VM to build HBase container
+
+```bash
+$ gcloud compute instances create thrift-builder \
+      --project $PROJECT_ID --zone $ZONE --image container-vm \
+      --scopes https://www.googleapis.com/auth/bigtable.admin.table,https://www.googleapis.com/auth/bigtable.data,https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/cloud-platform
+
+$ gcloud compute ssh thrift-builder --project $PROJECT_ID --zone $ZONE
+```
+
+Upgrade the Cloud SDK so we know we're working with the latest:
+
+    $ sudo gcloud components update
+
+Put the current user in the `docker` group. You'll need to log-in and out again
+for this command to take effect!
+
+    $ sudo usermod -a -G docker $USER
+
+If you're running this step on a Google Compute Engine VM but did all your
+previous work on your computer, be sure to re-export the same environment
+variables as previously, before continuing:
+
+    $ export PROJECT_ID=<my-project-id>
+    $ export ZONE=<my-zone>
+    $ export CLUSTER_ID=<my-cluster-id>
+    $ export BUCKET=<my-gcs-bucket>
+
+### Configure and build the HBase Thrift gateway Docker container
+
+The following command will download the HBase client, unpack it, and configure
+it to connect to Cloud Bigtable:
+
+    $ make install-hbase
+
+Now we're ready to build the Docker container.
+
+**Note:** if you have a domain-scoped project such as
+`example.com:my-project-id`, since Docker does not allow `:` in container names,
+we need to change that. For Docker 1.8+, the format is `example.com/my-project-id`.
+
+Here, we assume that you're using Docker 1.8+, so create a new environment
+variable to hold the Docker-appropriate project id:
+
+    $ export DOCKER_PROJECT_ID=${PROJECT_ID/://}
+
+If you are not using a domain-scoped project, this will just set it to
+`$PROJECT_ID`, which is fine.
+
+> _Note:_ for Docker prior to 1.8, you'll need to use the format `b.gcr.io/$BUCKET`
+which will store images in your Google Cloud Storage bucket; see the
+[documentation][docker-prior-to-1.8-docs] for more details. You'll need to
+modify both the [`Makefile`](thrift-gateway/Makefile) as well as
+[`deployment.jinja`](thrift-gateway/deployment.jinja) files appropriately.
+
+Next, run:
+
+    $ make docker-build
+
+> (optional) If you are running on Google Compute Engine VM, you can now run this
+container locally with the command:
+>
+>     $ make docker-run
+>
+> This will fail with insufficient permissions on your computer because the
+container will not have the credentials to access Google Cloud Storage, but on a
+Google Compute Engine VM it can pick up the authorization from the environment
+set up by the VM.
+
+Once we are done with the build, we can push this container to the Google
+Container Registry:
+
+    $ make docker-push
+
+  [docker-prior-to-1.8-docs]: https://cloud.google.com/container-registry/docs/#pushing_to_the_registry
+
+<a name="deploy-thrift-gateway-cluster"></a>
+## Deploy the HBase Thrift gateway cluster
+
+This step can be done from your local workstation.
+
+Run the following command to update the
+[`thrift-gateway/deployment.yaml`](thrift-gateway/deployment.yaml) file
+to change the zone and cluster name defined above and location where we stored
+the `stunnel.pem` file, which is the Cloud Storage bucket:
+
+    $ cd thrift-gateway
+    $ make update-deployment-config
+
+The `deployment.yaml` file might now look like the following example with your
+own values for cluster name and bucket:
+
+```yaml
+imports:
+- path: deployment.jinja
+
+resources:
+- name: deployment
+  type: deployment.jinja
+  properties:
+    zone: us-central1-b
+    cluster_id: my-cluster-id
+    docker_project_id: my-project-id
+    key_object: gs://my-bucket-name/stunnel.pem
+    region: us-central1
+```
+
+Deploy the cluster to your project:
+
+    $ make deploy-gateway
+
+Once complete, you can find the IP address of the deployed cluster via:
+
+    $ make print-thrift-gateway-lb-ip
+
+Save the IP address that is output by the above command.
+
+We can communicate to this endpoint on port 1090 by supplying the certificate
+in the `stunnel.pem` file.
+
+<a name="connect-appengine-to-thrift-gateway"></a>
+## Connect from App Engine to the Thrift gateway
+
+First, we'll need to install required Python dependencies (happybase and Thrift):
+
+    $ cd appengine
+    $ make pip-install
+
+> Note: This will use the `pip` command which is present in all recent Python
+> distributions. If you don't have it, you can install it on Linux distributions
+> via the [package manager][linux-pip-install]; on OS X, run the following
+> command:
+>
+>     $ sudo easy_install pip
+
+  [linux-pip-install]: https://packaging.python.org/en/latest/install_requirements_linux/
+
+Edit the source code to specify the load balancer IP you derived above by
+changing this line in [`bigtable.py`](appengine/bigtable.py) appropriately:
+
+    return SecureConnection('<Thrift gateway load balancer IP>', 1090)
+
+Now we can deploy the app:
+
+    $ make deploy
+
+Now you can visit the app at:
+
+    https://thrift-gateway-dot-$PROJECT_ID.appspot.com
+
+The app will guide you to create, list, and delete tables.
+
+If you have gotten this far, congratulations! You now have a working App Engine
+app which connects to Cloud Bigtable via the Thrift gateway. Note that the
+application is unsecured, so you should either add authentication and
+authorization or remove the app.
+
+<a name="troubleshooting"></a>
+## Troubleshooting
+
+Maybe everything didn't go perfectly. If the client can't connect to the Thrift
+gateway because of a connection refused error perhaps the serves didn't start.
+
+You can find a list of instances running the thrift gateway by going to the
+compute engine instances page of your project or by running:
+
+    $ gcloud compute instances list
+
+The thrift-gateway instances will be named something like
+`thrift-gateway-instance-xxxx`. Let's ssh into the instance from the command
+line or by clicking the "SSH" button next to the instance in the Cloud Console.
+
+    $ gcloud compute ssh thrift-gateway-instance-xxxx
+
+Once on the machine you can view the logs for the kubelet process which is
+responsible for starting the Docker containers running the gateway:
+
+    $ cat /var/log/kubelet.log
+
+If the Thrift gateway fails to start, you should be able to see quick running
+Docker containers with the docker ps command:
+
+    $ sudo docker ps -a
+
+You can inspect the container to verify that it was started with the correct
+environment variables pointing to the `stunnel.pem` file and Bigtable cluster
+name
+
+    $ sudo docker inspect <container-id>
+
+Or even see the standard out of the docker container that failed to start
+
+    $ sudo docker logs <container-id>
+
+Perhaps it couldn't download the `stunnel.pem` object due to a 403 permissions
+error. Verify you can access the object yourself from the GCE instance using
+`gsutil`.
+
+If the Python client is able to connect but is throwing an error, perhaps you
+didn't enable the Bigtable APIs in the project.

--- a/python/thrift/appengine-ssl-gateway/appengine/.gitignore
+++ b/python/thrift/appengine-ssl-gateway/appengine/.gitignore
@@ -1,0 +1,2 @@
+stunnel.pem
+third_party/python/managed

--- a/python/thrift/appengine-ssl-gateway/appengine/Makefile
+++ b/python/thrift/appengine-ssl-gateway/appengine/Makefile
@@ -1,0 +1,38 @@
+#!/bin/bash -eu
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+include ../common.mk
+
+THIRD_PARTY_PYTHON_MANAGED_LIBS = third_party/python/managed
+
+pip-install:
+	$(VERB) mkdir -p $(THIRD_PARTY_PYTHON_MANAGED_LIBS)
+	$(VERB) pip install -r requirements.txt -t $(THIRD_PARTY_PYTHON_MANAGED_LIBS)
+
+KEY_FILE = stunnel.pem
+
+# $(KEY_FILE) should have been produced by an earlier step and copied to this
+# directory as well as to a GCS bucket. If it's missing, the user skipped that
+# step.
+deploy: env_project_id
+	$(VERB) if ! [ -e $(KEY_FILE) ]; then echo >&2 "$(KEY_FILE) missing"; exit 1; fi
+	$(VERB) gcloud preview app deploy app.yaml \
+	            --project $$PROJECT_ID --version thrift-gateway --no-promote
+
+clean:
+	$(VERB) rm -rf $(THIRD_PARTY_PYTHON_MANAGED_LIBS)

--- a/python/thrift/appengine-ssl-gateway/appengine/app.yaml
+++ b/python/thrift/appengine-ssl-gateway/appengine/app.yaml
@@ -1,0 +1,32 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+runtime: python27
+api_version: 1
+threadsafe: true
+
+handlers:
+- url: /.*
+  script: bigtable.app
+  secure: always
+
+libraries:
+- name: jinja2
+  version: latest
+- name: ssl
+  version: latest
+- name: webapp2
+  version: latest

--- a/python/thrift/appengine-ssl-gateway/appengine/appengine_config.py
+++ b/python/thrift/appengine-ssl-gateway/appengine/appengine_config.py
@@ -1,0 +1,20 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration to add third party Python libraries to the search path."""
+
+from google.appengine.ext import vendor
+
+# Add any libraries automatically installed by pip.
+vendor.add('third_party/python/managed')

--- a/python/thrift/appengine-ssl-gateway/appengine/bigtable.py
+++ b/python/thrift/appengine-ssl-gateway/appengine/bigtable.py
@@ -1,0 +1,117 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google App Engine application which connects to Google Cloud Bigtable via
+the HBase Thrift proxy servers."""
+
+# Standard Python libraries.
+import logging
+import os
+
+# Libraries provided by App Engine.
+import jinja2
+import webapp2
+
+# Additional imports we provide ourselves.
+import happybase
+from happybase.hbase import Hbase
+from happybase.hbase import ttypes
+from thrift.transport.TSSLSocket import TSSLSocket
+
+JINJA_ENVIRONMENT = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(os.path.dirname(__file__)),
+    autoescape=True,
+    extensions=['jinja2.ext.autoescape'])
+
+KEY_FILE = 'stunnel.pem'
+
+
+class SecureConnection(happybase.Connection):
+    def _refresh_thrift_client(self):
+        """Refresh the Thrift socket, transport, and client."""
+        socket = TSSLSocket(self.host, self.port, False, KEY_FILE, KEY_FILE,
+            KEY_FILE)
+        if self.timeout is not None:
+            socket.setTimeout(self.timeout)
+        self.transport = self._transport_class(socket)
+        protocol = self._protocol_class(self.transport)
+        self.client = Hbase.Client(protocol)
+
+
+def CreateConnection():
+    # Change this to be your load balancer's IP address.
+    # TODO: add automatic lookup, via Compute APIs? Cache results.
+    return SecureConnection('<Thrift gateway load balancer IP>', 1090)
+
+
+class IndexHandler(webapp2.RequestHandler):
+
+    def get(self):
+        connection = CreateConnection()
+        tables = connection.tables()
+
+        variables = {'tables': tables}
+        template = JINJA_ENVIRONMENT.get_template('web/index.jinja')
+        self.response.write(template.render(variables))
+
+
+class CreateTableHandler(webapp2.RequestHandler):
+    def get(self):
+        connection = CreateConnection()
+        table = 'mytable'
+        status = 'does not exist'
+        try:
+            connection.create_table(
+                'mytable',
+                {'cf1': dict(max_versions=10),
+                 'cf2': dict(max_versions=1, block_cache_enabled=False),
+                 'cf3': dict(),  # use defaults
+                }
+            )
+            status = 'was created'
+        except ttypes.AlreadyExists:
+            status = 'already exists'
+
+        variables = {'table': table, 'status': status}
+        template = JINJA_ENVIRONMENT.get_template('web/create.jinja')
+        self.response.write(template.render(variables))
+
+
+class DeleteTableHandler(webapp2.RequestHandler):
+    def get(self):
+        connection = CreateConnection()
+        table = 'mytable'
+        status = 'invalid'
+        try:
+            connection.delete_table(table, disable=True)
+            status = 'deleted'
+        except Exception as e:
+            # FIXME(mbrukman): the actual exception thrown is IOError, but trying
+            # to catch it specifically does not seem to work.
+            notFound = 'TableNotFoundException: %s' % table
+            if notFound in repr(e):
+                status = 'not found'
+
+        variables = {'table' : table, 'status': status}
+        template = JINJA_ENVIRONMENT.get_template('web/delete.jinja')
+        self.response.write(template.render(variables))
+
+
+app = webapp2.WSGIApplication(
+    [
+        webapp2.Route('/', IndexHandler),
+        webapp2.Route('/create', CreateTableHandler),
+        webapp2.Route('/delete', DeleteTableHandler),
+    ],
+    debug=True)

--- a/python/thrift/appengine-ssl-gateway/appengine/requirements.txt
+++ b/python/thrift/appengine-ssl-gateway/appengine/requirements.txt
@@ -1,0 +1,1 @@
+happybase

--- a/python/thrift/appengine-ssl-gateway/appengine/web/create.jinja
+++ b/python/thrift/appengine-ssl-gateway/appengine/web/create.jinja
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <title>Bigtable table: create</title>
+  </head>
+  <body>
+{% if 'created' in status %}
+    Congrats!
+{% endif %}
+
+    Your Bigtable table <code>{{ table }}</code> {{ status }}.<br>
+
+{% if 'created' in status %}
+    Refresh this page to see what happens if you try to recreate it.<br>
+{% endif %}
+
+    Now you can <a href="/">list</a> or <a href="/delete">delete</a> your table.
+  </body>
+</html>

--- a/python/thrift/appengine-ssl-gateway/appengine/web/delete.jinja
+++ b/python/thrift/appengine-ssl-gateway/appengine/web/delete.jinja
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <title>Bigtable table: delete</title>
+  </head>
+  <body>
+    Your Bigtable table <code>{{ table }}</code> was {{ status }}.<br>
+
+{% if 'deleted' in status %}
+    Refresh this page to see what happens if you try to delete it again.<br>
+{% endif %}
+
+    Now you can <a href="/">list</a> your tables or <a href="/create">create</a> a new table.<br>
+  </body>
+</html>

--- a/python/thrift/appengine-ssl-gateway/appengine/web/index.jinja
+++ b/python/thrift/appengine-ssl-gateway/appengine/web/index.jinja
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <title>Bigtable table: index</title>
+  </head>
+  <body>
+{% if not tables %}
+    You have no tables created; please visit the <a href="/create">create</a>
+    page to do so.
+{% else %}
+    Congrats! You have created the following tables: <code>{{ tables }}</code>.<br>
+    You can now
+  {% if 'mytable' in tables %}
+    <a href="/delete">delete</a>
+  {% else %>
+    <a href="/create">create</a>
+  {% endif %}
+    the <code>mytable</code> table.
+{% endif %}
+  </body>
+</html>

--- a/python/thrift/appengine-ssl-gateway/common.mk
+++ b/python/thrift/appengine-ssl-gateway/common.mk
@@ -1,0 +1,41 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+VERB = @
+ifeq ($(VERBOSE),1)
+	VERB =
+endif
+
+default:
+	$(VERB) echo "Follow instructions in README.md"
+
+# Ensure common env vars are set up properly.
+# TODO: automatically pick up PROJECT_ID, ZONE if running on GCE.
+
+env_project_id:
+	$(VERB) if [ -z "$${PROJECT_ID}" ]; then echo '$$PROJECT_ID not set'; exit 1; fi
+
+env_zone:
+	$(VERB) if [ -z "$${ZONE}" ]; then echo '$$ZONE not set'; exit 1; fi
+
+env_cluster_id:
+	$(VERB) if [ -z "$${CLUSTER_ID}" ]; then echo '$$CLUSTER_ID not set'; exit 1; fi
+
+env_bucket:
+	$(VERB) if [ -z "$${BUCKET}" ]; then echo '$$BUCKET not set'; exit 1; fi
+
+env_docker_project_id:
+	$(VERB) if [ -z "$${DOCKER_PROJECT_ID}" ]; then echo '$$DOCKER_PROJECT_ID not set'; exit 1; fi

--- a/python/thrift/appengine-ssl-gateway/thrift-gateway/.gitignore
+++ b/python/thrift/appengine-ssl-gateway/thrift-gateway/.gitignore
@@ -1,0 +1,3 @@
+hbase-*.tar.gz
+hbase-*/
+stunnel.pem

--- a/python/thrift/appengine-ssl-gateway/thrift-gateway/Dockerfile
+++ b/python/thrift/appengine-ssl-gateway/thrift-gateway/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM debian:7
+
+ENV VERSION 1.1
+
+RUN apt-get -yyq update
+RUN apt-get -yq install openjdk-7-jre-headless stunnel curl libtcnative-1
+
+# Install Google Cloud SDK in order to run `gsutil`.
+RUN export CLOUD_SDK_REPO=cloud-sdk-wheezy; echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list; curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -; apt-get update && apt-get install -yq google-cloud-sdk python
+
+ADD hbase-1.1.2 hbase-1.1.2
+ADD start-thrift.sh start-thrift.sh
+
+EXPOSE 9090 1090
+
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
+
+CMD ./start-thrift.sh

--- a/python/thrift/appengine-ssl-gateway/thrift-gateway/Makefile
+++ b/python/thrift/appengine-ssl-gateway/thrift-gateway/Makefile
@@ -1,0 +1,86 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+include ../common.mk
+
+# Deploying the Thrift gateway
+
+REGION = us-central1
+
+KEY_FILE = stunnel.pem
+ssl-key: $(KEY_FILE)
+
+$(KEY_FILE):
+	$(VERB) openssl req -new -days 365000 -x509 -nodes -out $(KEY_FILE) -keyout $(KEY_FILE) -subj "/C=US/ST=NY/L=New_York/O=Dis/CN=www.example.com" -pubkey
+	$(VERB) cp -f $(KEY_FILE) ../appengine
+
+copy-ssl-key-to-gcs: $(KEY_FILE) env_project_id env_bucket
+	$(VERB) gsutil mb -p $$PROJECT_ID gs://$$BUCKET || gsutil ls gs://$$BUCKET
+	$(VERB) gsutil cp $(KEY_FILE) gs://$$BUCKET/$(KEY_FILE)
+
+DEPLOYMENT_CONFIG = deployment.yaml
+DEPLOYMENT = thrift-gateway
+
+update-deployment-config: env_cluster_id env_zone env_bucket env_docker_project_id
+	$(VERB) sed -i 's/<CLUSTER_ID>/'$$CLUSTER_ID'/g' $(DEPLOYMENT_CONFIG)
+	$(VERB) sed -i 's@<BUCKET>@'"$$BUCKET"'@g' $(DEPLOYMENT_CONFIG)
+	$(VERB) sed -i 's@<DOCKER_PROJECT_ID>@'"$$DOCKER_PROJECT_ID"'@g' $(DEPLOYMENT_CONFIG)
+	$(VERB) sed -i 's/<ZONE>/'$$ZONE'/g' $(DEPLOYMENT_CONFIG)
+
+deploy-gateway:
+	$(VERB) gcloud deployment-manager deployments create $(DEPLOYMENT) --config $(DEPLOYMENT_CONFIG)
+
+delete-gateway:
+	$(VERB) gcloud deployment-manager deployments delete $(DEPLOYMENT)
+
+print-thrift-gateway-lb-ip:
+	$(VERB) gcloud compute forwarding-rules describe thrift-gateway-lb --region $(REGION) | grep IPAddress | sed 's/IPAddress: //'
+
+# Docker container for the Thrift gateway
+
+HBASE_VERSION = 1.1.2
+HBASE_TAR_GZ = hbase-$(HBASE_VERSION)-bin.tar.gz
+HBASE_DIR = hbase-$(HBASE_VERSION)
+
+download-hbase: $(HBASE_TAR_GZ)
+
+$(HBASE_TAR_GZ):
+	$(VERB) curl "https://archive.apache.org/dist/hbase/$(HBASE_VERSION)/$(HBASE_TAR_GZ)" -f -o "$@"
+
+install-hbase: $(HBASE_TAR_GZ)
+	$(VERB) ./install-hbase.sh
+
+hbase-$(HBASE_VERSION): install-hbase
+
+DOCKER_CONTAINER_NAME = thrift-gateway
+
+docker-build: env_docker_project_id hbase-$(HBASE_VERSION)
+	$(VERB) docker build -t gcr.io/$$DOCKER_PROJECT_ID/$(DOCKER_CONTAINER_NAME) .
+
+docker-run: env_project_id env_zone env_cluster_id env_bucket env_docker_project_id
+	$(VERB) docker run -ti -e KEY_OBJECT=gs://$$BUCKET/$(KEY_FILE) \
+          -e CLUSTER_ID=$$CLUSTER_ID -e PROJECT=$$PROJECT_ID \
+          -e ZONE=$$ZONE -p 1090:1090 -p 9090:9090 \
+          gcr.io/$$DOCKER_PROJECT_ID/$(DOCKER_CONTAINER_NAME)
+
+docker-pull: env_docker_project_id
+	$(VERB) gcloud docker pull gcr.io/$$DOCKER_PROJECT_ID/$(DOCKER_CONTAINER_NAME)
+
+docker-push: env_docker_project_id
+	$(VERB) gcloud docker push gcr.io/$$DOCKER_PROJECT_ID/$(DOCKER_CONTAINER_NAME)
+
+clean:
+	$(VERB) rm -f $(KEY_FILE) $(HBASE_TAR_GZ) $(HBASE_DIR)

--- a/python/thrift/appengine-ssl-gateway/thrift-gateway/deployment.jinja
+++ b/python/thrift/appengine-ssl-gateway/thrift-gateway/deployment.jinja
@@ -1,0 +1,114 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+resources:
+  - name: thrift-gateway-it
+    type: compute.v1.instanceTemplate
+    properties:
+      properties:
+        disks:
+        - autoDelete: true
+          boot: true
+          deviceName: boot
+          initializeParams:
+            sourceImage: https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20160127
+          mode: READ_WRITE
+          type: PERSISTENT
+        machineType: n1-standard-1
+        serviceAccounts:
+          - email: default
+            scopes:
+              - https://www.googleapis.com/auth/bigtable.admin.table
+              - https://www.googleapis.com/auth/bigtable.data
+              - https://www.googleapis.com/auth/devstorage.full_control
+        metadata:
+          items:
+          - key: google-container-manifest
+            value: |
+              version: v1
+              kind: Pod
+              metadata:
+                name: thrift-gateway
+              spec:
+                containers:
+                  - name: thrift-gateway
+                    image: gcr.io/{{ properties['docker_project_id'] }}/thrift-gateway
+                    imagePullPolicy: IfNotPresent
+                    env:
+                       - name: CLUSTER_ID
+                         value: {{ properties['cluster_id'] }}
+                       - name: ZONE
+                         value: {{ properties['zone'] }}
+                       - name: PROJECT
+                         value: {{ env['project'] }}
+                       - name: KEY_OBJECT
+                         value: {{ properties['key_object'] }}
+                    ports:
+                      - containerPort: 9090
+                        name: thrift
+                        hostPort: 9090
+                        protocol: TCP
+                      - containerPort: 1090
+                        hostPort: 1090
+                        name: stunnel
+                        protocol: TCP
+                restartPolicy: Always
+                DNSPolicy: Default
+        networkInterfaces:
+        - accessConfigs:
+          - name: external-nat
+            type: ONE_TO_ONE_NAT
+          network: https://www.googleapis.com/compute/v1/projects/{{ env['project'] }}/global/networks/default
+
+  - name: thrift-gateway-igm
+    type: compute.v1.instanceGroupManager
+    properties:
+      baseInstanceName: thrift-gateway-instance
+      instanceTemplate: $(ref.thrift-gateway-it.selfLink)
+      targetPools:
+      - $(ref.thrift-gateway-tp.selfLink)
+      targetSize: 2
+      zone: {{ properties['zone'] }}
+
+  - name: thrift-gateway-tp
+    type: compute.v1.targetPool
+    properties:
+      region: {{ properties['region'] }}
+
+  - name: thrift-gateway-as
+    type: compute.v1.autoscaler
+    properties:
+      autoscalingPolicy:
+        maxNumReplicas: 10
+      target: $(ref.thrift-gateway-igm.selfLink)
+      zone: {{ properties['zone'] }}
+
+  - name: thrift-gateway-lb
+    type: compute.v1.forwardingRule
+    properties:
+      portRange: 1090
+      region: us-central1
+      target: $(ref.thrift-gateway-tp.selfLink)
+
+  - name: thrift-gateway-fw
+    type: compute.v1.firewall
+    properties:
+      allowed:
+      - IPProtocol: TCP
+        ports:
+        - 1090
+      sourceRanges:
+      - 0.0.0.0/0

--- a/python/thrift/appengine-ssl-gateway/thrift-gateway/deployment.yaml
+++ b/python/thrift/appengine-ssl-gateway/thrift-gateway/deployment.yaml
@@ -1,0 +1,32 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# Launches an autoscaled, load-balanced pool of Thrift gateway servers.
+#
+################################################################################
+
+imports:
+- path: deployment.jinja
+
+resources:
+- name: deployment
+  type: deployment.jinja
+  properties:
+    zone: <ZONE>
+    cluster_id: <CLUSTER_ID>
+    docker_project_id: <DOCKER_PROJECT_ID>
+    key_object: gs://<BUCKET>/stunnel.pem
+    region: us-central1

--- a/python/thrift/appengine-ssl-gateway/thrift-gateway/install-hbase.sh
+++ b/python/thrift/appengine-ssl-gateway/thrift-gateway/install-hbase.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -eu
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Install the HBase client.
+if [ ! -e "hbase-1.1.2" ]; then
+  echo "Unpacking HBase ..."
+  tar xaf hbase-1.1.2-bin.tar.gz
+  echo "Done."
+fi
+
+# Args:
+#   $1: URL to download
+#   $2: target file to save the URL contents as
+function download_url_to_file() {
+  local url="$1"
+  local file="$2"
+  if [ ! -e "${file}" ]; then
+    echo "Downloading ${url} ..."
+    curl -s "${url}" -f -o "${file}"
+  else
+    echo "INFO: skipping download of $(basename ${url}); already done."
+  fi
+}
+
+# Install the Cloud Bigtable connector.
+mkdir -p hbase-1.1.2/lib/bigtable
+
+download_url_to_file https://repo.maven.apache.org/maven2/io/netty/netty-tcnative/1.1.33.Fork9/netty-tcnative-1.1.33.Fork9-linux-x86_64.jar \
+    hbase-1.1.2/lib/bigtable/netty-tcnative-1.1.33.Fork9-linux-x86_64.jar
+download_url_to_file http://repo1.maven.org/maven2/com/google/cloud/bigtable/bigtable-hbase-1.1/0.2.3/bigtable-hbase-1.1-0.2.3.jar \
+    hbase-1.1.2/lib/bigtable/bigtable-hbase-1.1-0.2.3.jar
+
+cat > hbase-1.1.2/conf/hbase-env.sh << EOF
+export HBASE_OPTS="-XX:+UseConcMarkSweepGC"
+export HBASE_MASTER_OPTS="${HBASE_MASTER_OPTS:-} -XX:PermSize=128m -XX:MaxPermSize=128m"
+export HBASE_REGIONSERVER_OPTS="${HBASE_REGIONSERVER_OPTS:-} -XX:PermSize=128m -XX:MaxPermSize=128m"
+export HBASE_CLASSPATH="lib/bigtable/bigtable-hbase-1.1-0.2.3.jar:lib/bigtable/netty-tcnative-1.1.33.Fork9-linux-x86_64.jar"
+export HBASE_OPTS="\${HBASE_OPTS} -Xms1024m -Xmx2048m"
+EOF

--- a/python/thrift/appengine-ssl-gateway/thrift-gateway/start-thrift.sh
+++ b/python/thrift/appengine-ssl-gateway/thrift-gateway/start-thrift.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -eu
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Download the stunnel certificate from GCS bucket
+gsutil cp $KEY_OBJECT .
+
+cat > hbase-1.1.2/conf/hbase-site.xml << EOF
+<configuration>
+  <property>
+    <name>hbase.client.connection.impl</name>
+    <value>com.google.cloud.bigtable.hbase1_1.BigtableConnection</value>
+  </property>
+  <property>
+    <name>hbase.thrift.connection.cleanup-interval</name>
+    <value>2147483647</value>
+  </property>
+  <property>
+    <name>hbase.thrift.connection.max-idletime</name>
+    <value>2147483647</value>
+  </property>
+  <property>
+    <name>google.bigtable.cluster.name</name>
+    <value>$CLUSTER_ID</value>
+  </property>
+  <property>
+    <name>google.bigtable.project.id</name>
+    <value>$PROJECT</value>
+  </property>
+  <property>
+    <name>google.bigtable.zone.name</name>
+    <value>$ZONE</value>
+  </property>
+</configuration>
+EOF
+
+stunnel -D debug -d 1090 -r 9090 -p stunnel.pem -P '' -v 3 -A stunnel.pem -o /var/log/stunnel.log
+cd hbase-1.1.2
+bin/hbase thrift start 2>&1 | tee /var/log/thrift.log


### PR DESCRIPTION
This howto provides instructions for creating an App Engine app which will
connect to a load-balanced, autoscaled managed instance group of HBase Thrift
gateways which will connect to Cloud Bigtable.

Many thanks to Ben Menasha for the initial version of these instructions.

@bmenasha, @lesv — please review and comment.