### PR TITLE
Update to client 0.2.4

### DIFF
--- a/java/dataflow-coinbase/dataflow/pom.xml
+++ b/java/dataflow-coinbase/dataflow/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.google.cloud.bigtable</groupId>
             <artifactId>bigtable-hbase-dataflow</artifactId>
-            <version>0.2.3</version>
+            <version>0.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/java/dataflow-coinbase/pom.xml
+++ b/java/dataflow-coinbase/pom.xml
@@ -27,7 +27,7 @@
     <version>0.1-SNAPSHOT</version>
 
     <properties>
-        <bigtable.version>0.2.3</bigtable.version>
+        <bigtable.version>0.2.4</bigtable.version>
         <hbase.version>1.1.1</hbase.version>
 
         <hadoop.version>2.4.1</hadoop.version>
@@ -50,10 +50,55 @@
         <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     </properties>
 
+
     <modules>
         <module>dataflow</module>
         <module>frontend</module>
     </modules>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>

--- a/java/dataflow-connector-examples/pom.xml
+++ b/java/dataflow-connector-examples/pom.xml
@@ -38,7 +38,7 @@ limitations under the License.
 
   <properties>
     <dataflow.version>1.0.0</dataflow.version>
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
     <!-- For Netty HTTP2/TLS negotiation -->
     <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>
     <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
@@ -49,6 +49,50 @@ limitations under the License.
     <compileSource>1.8</compileSource>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>

--- a/java/dataflow-import-examples/pom.xml
+++ b/java/dataflow-import-examples/pom.xml
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <bigtable.hbase.version>0.2.4-SNAPSHOT</bigtable.hbase.version>
+    <bigtable.hbase.version>0.2.4</bigtable.hbase.version>
     <!-- For Netty HTTP2/TLS negotiation -->
     <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>
     <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
@@ -26,6 +26,50 @@
     <compileSource>1.7</compileSource>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>

--- a/java/dataflow-pardo-helloworld/pom.xml
+++ b/java/dataflow-pardo-helloworld/pom.xml
@@ -19,11 +19,55 @@
 
   <properties>
     <dataflow.version>1.0.0</dataflow.version>
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
     <compileSource>1.8</compileSource>
     
     <bigtable.hbase.version>${bigtable.version}</bigtable.hbase.version>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
         <dependency>
@@ -37,20 +81,6 @@
             <version>${bigtable.version}</version>
         </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>staged</id> 
-      <repositories>
-        <repository>
-          <id>snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <releases><enabled>false</enabled></releases>
-          <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
 
   <build>
     <plugins>

--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -26,10 +26,54 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
     <hbase.version>1.1.1</hbase.version>
-    <compileSource>1.7</compileSource>
+    <compileSource>1.8</compileSource>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>

--- a/java/managed-vm-gae/pom.xml
+++ b/java/managed-vm-gae/pom.xml
@@ -27,7 +27,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
     <hbase.version>1.1.2</hbase.version>
     <bigtable.projectID>YOUR_PROJECT_ID</bigtable.projectID>
     <bigtable.clusterID>YOUR_CLUSTER_ID</bigtable.clusterID>
@@ -36,20 +36,64 @@
     <hadoop.version>2.4.1</hadoop.version>
     <compat.module>hbase-hadoop2-compat</compat.module>
 
-    <appengine.version>1.9.32</appengine.version>
-    <gcloud.plugin.version>2.0.9.95.v20160203</gcloud.plugin.version>
+    <appengine.version>1.9.34</appengine.version>
+    <gcloud.plugin.version>2.0.9.101.v20160316</gcloud.plugin.version>
     
     <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for MVMs -->
 
     <slf4j.version>1.7.12</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
 
-
     <requiredMavenVersion>3.3.3</requiredMavenVersion>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
+
 
   <dependencies>
     <dependency>
@@ -87,17 +131,6 @@
   </dependencies>
 
   <profiles>
-    <profile>
-      <id>staged</id> 
-      <repositories>
-        <repository>
-          <id>snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <releases><enabled>false</enabled></releases>
-          <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-      </repositories>
-    </profile>
     <profile>
       <id>mac</id>
       <properties>

--- a/java/simple-cli/hbasecli.sh
+++ b/java/simple-cli/hbasecli.sh
@@ -1,10 +1,3 @@
 #!/bin/sh
 
-LOCAL_REPOSITORY=`mvn help:evaluate -Dexpression=settings.localRepository | grep -v '[INFO]'`
-ALPN_VERSION=`mvn help:evaluate -Dexpression=alpn.version | grep -v '[INFO]'`
-
-# mvn dependency:build-classpath -DincludeScope=runtime -Dmdep.outputFile=cp.txt > /dev/null
-# CPATH=`cat cp.txt`
-# rm cp.txt
-
-java -Xbootclasspath/p:${LOCAL_REPOSITORY}/org/mortbay/jetty/alpn/alpn-boot/${ALPN_VERSION}/alpn-boot-${ALPN_VERSION}.jar -jar target/cloud-bigtable-simple-cli-1.0-SNAPSHOT-jar-with-dependencies.jar $@
+java -jar target/cloud-bigtable-simple-cli-1.0-SNAPSHOT-jar-with-dependencies.jar $@

--- a/java/simple-cli/pom.xml
+++ b/java/simple-cli/pom.xml
@@ -14,16 +14,57 @@
     <bigtable.clusterID>YOUR_CLUSTER_ID</bigtable.clusterID>
     <bigtable.zone>us-central1-b</bigtable.zone>
 
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
 
     <hadoop.version>2.4.1</hadoop.version>
     <hbase.version>1.1.1</hbase.version>
 
-    <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>
-    <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
-
     <compileSource>1.8</compileSource>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>
@@ -45,46 +86,23 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mortbay.jetty.alpn</groupId>
-      <artifactId>alpn-boot</artifactId>
-      <version>${alpn.version}</version>
-      <scope>test</scope>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork13</version>
+      <classifier>${os.detected.classifier}</classifier>
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>staged</id> 
-      <repositories>
-        <repository>
-          <id>snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <releases><enabled>false</enabled></releases>
-          <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-      </repositories>
-    </profile>
-    <profile>
-      <id>jdk7</id>
-        <activation>
-            <jdk>1.7</jdk>
-        </activation>
-        <properties>
-            <alpn.version>${alpn.jdk7.version}</alpn.version>
-        </properties>
-    </profile>
-    <profile>
-        <id>jdk8</id>
-        <activation>
-            <jdk>1.8</jdk>
-        </activation>
-        <properties>
-            <alpn.version>${alpn.jdk8.version}</alpn.version>
-        </properties>
-    </profile>
-  </profiles>
-
   <build>
+    <extensions>
+      <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.4.0.Final</version>
+      </extension>
+    </extensions>
+
     <resources>
       <resource>
         <directory>src/main/resources</directory>
@@ -102,6 +120,30 @@
             <showDeprecation>false</showDeprecation>
             <compilerArgument>-Xlint:-options</compilerArgument>
         </configuration>
+      </plugin>
+
+      <!-- Use Ant to configure the appropriate "tcnative.classifier" property -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <condition property="tcnative.classifier"
+                           value="${os.detected.classifier}-fedora"
+                           else="${os.detected.classifier}">
+                  <isset property="os.detected.release.fedora"/>
+                </condition>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/java/simple-performance-test/pom.xml
+++ b/java/simple-performance-test/pom.xml
@@ -27,10 +27,54 @@
 
   <properties>
     <bigtable.zone>us-central1-b</bigtable.zone>
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
     <hbase.version>1.1.3</hbase.version>
     <compileSource>1.8</compileSource>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>

--- a/java/wordcount-mapreduce/README.md
+++ b/java/wordcount-mapreduce/README.md
@@ -76,7 +76,7 @@ The command by default spins up 4 `n1-standard-4 worker` nodes and a single `n1-
 
 The actual `gcloud` command:
 
-    gcloud beta dataproc clusters create dp --bucket MYBUCKET --initialization-actions \
+    gcloud dataproc clusters create dp --bucket MYBUCKET --initialization-actions \
         gs://MYBUCKET/bigtable-dataproc-init.sh --num-workers 4 --zone us-central1-b \
         --master-machine-type n1-standard-4 --worker-machine-type n1-standard-4
 
@@ -90,7 +90,7 @@ The helper script can also start a job for you.
 
 This is an alias for the `gcloud` command:
 
-    gcloud beta dataproc jobs submit hadoop --cluster dp --async \
+    gcloud dataproc jobs submit hadoop --cluster dp --async \
         --jar target/wordcount-mapreduce-0-SNAPSHOT.jar \
         wordcount-hbase <sourceFiles> <outputTable>
 

--- a/java/wordcount-mapreduce/bigtable-dataproc-init.sh
+++ b/java/wordcount-mapreduce/bigtable-dataproc-init.sh
@@ -15,13 +15,10 @@
 
 # Values you must set
 
-ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 PROJECT=$(/usr/share/google/get_metadata_value project-id)
-BUCKET=$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)
 
-# echo "*****"
-# gcloud -q components update
-# gcloud -q components update alpha beta
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+BUCKET=$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)
 
 echo "Copying files from Bucket"
 gsutil -q cp gs://${BUCKET}/hbase-site.xml /etc/hadoop/conf/
@@ -37,5 +34,3 @@ echo "Adding classpath's"
 echo "export HADOOP_CLASSPATH=\"$(/usr/bin/hbase mapredcp):\$HADOOP_CLASSPATH\"" >> /etc/hadoop/conf/hadoop-env.sh
 echo "export HADOOP_CLASSPATH=\"$(/usr/bin/hbase mapredcp):\$HADOOP_CLASSPATH\"" >> /etc/hadoop/conf/mapred-env.sh
 
-# make it so we can use hbase if we need to.  (ie. hbase shell)
-echo "HBASE_OPTS=\"\${HBASE_OPTS} -Xbootclasspath/p:\${ALPN_JAR}\"" >> /etc/hbase/conf/hbase-env.sh

--- a/java/wordcount-mapreduce/cluster.sh
+++ b/java/wordcount-mapreduce/cluster.sh
@@ -64,7 +64,7 @@ create)   # create <bucket> [<clusterName> [zone]]
   ZONE=${4:-$DEFAULT_ZONE}
   CLUSTER="${3:-$DEFAULT_CLUSTER}"
   
-  gcloud ${PHASE} dataproc clusters create "${CLUSTER}" \
+  gcloud dataproc clusters create "${CLUSTER}" \
     --bucket "$2" \
     --initialization-actions "gs://$2/bigtable-dataproc-init.sh" \
     --num-workers 4 \
@@ -84,7 +84,7 @@ start)  # start [<clusterName>]
   CLUSTER="${2:-$DEFAULT_CLUSTER}"
 
   TARGET="WordCount-$(date +%s)"
-  gcloud ${PHASE} dataproc jobs submit hadoop --cluster "$CLUSTER" \
+  gcloud dataproc jobs submit hadoop --cluster "$CLUSTER" \
     --jar target/wordcount-mapreduce-0-SNAPSHOT.jar wordcount-hbase \
     gs://lesv-big-public-data/books/book \
     gs://lesv-big-public-data/books/b10 \

--- a/java/wordcount-mapreduce/pom.xml
+++ b/java/wordcount-mapreduce/pom.xml
@@ -31,7 +31,7 @@
     <bigtable.clusterID>YOUR_CLUSTER_ID_HERE</bigtable.clusterID>
     <bigtable.zone>us-central1-b</bigtable.zone>
 
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
     <hbase.version>1.0.1.1</hbase.version><!-- needs to match Dataproc HBase version -->
     <hbase.if>1.0</hbase.if> <!-- hbase interface - it changed between 1.0 and 1.1.x -->
 
@@ -42,6 +42,51 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
+
 
   <dependencies>
     <dependency>
@@ -62,20 +107,6 @@
     </dependency>
 
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>staged</id> 
-      <repositories>
-        <repository>
-          <id>snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <releases><enabled>false</enabled></releases>
-          <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
 
   <build>
     <outputDirectory>target/${project.artifactId}-${project.version}/WEB-INF/classes</outputDirectory> 

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -17,18 +17,62 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>cloud-bigtable</groupId>
-  <artifactId>testing</artifactId>
+  <artifactId>quickstart</artifactId>
   <version>0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
-    <bigtable.version>0.2.3</bigtable.version>
+    <bigtable.version>0.2.4</bigtable.version>
     <hbase.version>1.1.2</hbase.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     
     <bigtable.zone>us-central1-b</bigtable.zone>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage.googleapis.com</url>
+      <layout>default</layout>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>
@@ -50,20 +94,6 @@
       <classifier>${os.detected.classifier}</classifier>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>staged</id> 
-      <repositories>
-        <repository>
-          <id>snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <releases><enabled>false</enabled></releases>
-          <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
 
   <build>
      <resources>


### PR DESCRIPTION
1. In most pom’s, add the sonatype snapshot repo. remove -Pstaged option. -Dbigtable.version=0.2.4-SNAPSHOT should work now w/o help.
2. In most pom’s add the Google-Maven-Central mirror
3. Dataproc is GA
4. Dataproc includes alpa-boot on the run line by default
5. Made simple-cli use boring-ssl, much faster.
6. Update to latest GAE / gcloud

Note - I left some data flow examples using alpa-boot as there are some
issues w/ boring-ssl and Docker containers. (Docker doesn’t like IPv6)

@sduskis @hegemonic @IanLewis @mbrukman FYI