### PR TITLE
fix: fail fast in java/wordcount-mapreduce init

### DIFF
--- a/java/wordcount-mapreduce/bigtable-dataproc-init.sh
+++ b/java/wordcount-mapreduce/bigtable-dataproc-init.sh
@@ -11,7 +11,9 @@
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
-#    limitations under the License.set -x -e
+#    limitations under the License.
+
+set -x -e
 
 # Values you must set
 


### PR DESCRIPTION
That was a typo, I guess