### PR TITLE
Update Client to 0.3.0

### DIFF
--- a/java/dataflow-pardo-helloworld/pom.xml
+++ b/java/dataflow-pardo-helloworld/pom.xml
@@ -27,6 +27,8 @@ permissions and limitations under the License.
     <compileSource>1.8</compileSource>
 
     <bigtable.hbase.version>${bigtable.version}</bigtable.hbase.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <repositories>
@@ -114,22 +116,6 @@ permissions and limitations under the License.
             </manifest>
           </archive>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <configuration>
-            <source>${compileSource}</source>
-            <target>${compileSource}</target>
-            <showWarnings>true</showWarnings>
-            <showDeprecation>false</showDeprecation>
-            <compilerArgument>-Xlint:-options</compilerArgument>
-        </configuration>
-      </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
       </plugin>
     </plugins>
   </build>

--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -26,9 +26,10 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <bigtable.version>0.2.4</bigtable.version>
-    <hbase.version>1.1.1</hbase.version>
-    <compileSource>1.8</compileSource>
+    <bigtable.version>0.3.0</bigtable.version>
+    <hbase.version>1.2.1</hbase.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <repositories>
@@ -108,18 +109,6 @@
     </extensions>
 
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <configuration>
-          <source>${compileSource}</source>
-          <target>${compileSource}</target>
-          <showWarnings>true</showWarnings>
-          <showDeprecation>false</showDeprecation>
-          <compilerArgument>-Xlint:-options</compilerArgument>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,7 +29,9 @@ limitations under the License.
     <module>dataproc-wordcount</module>
     <module>gae-flexible-helloworld</module>
     <module>hello-world</module>
+<!-- 
     <module>jetty-managed-vm</module>
+ -->
     <module>simple-cli</module>
     <module>simple-performance-test</module>
     <module>storm</module>

--- a/java/simple-cli/pom.xml
+++ b/java/simple-cli/pom.xml
@@ -14,12 +14,13 @@
     <bigtable.clusterID>YOUR_CLUSTER_ID</bigtable.clusterID>
     <bigtable.zone>us-central1-b</bigtable.zone>
 
-    <bigtable.version>0.2.4</bigtable.version>
+    <bigtable.version>0.3.0</bigtable.version>
 
     <hadoop.version>2.4.1</hadoop.version>
-    <hbase.version>1.1.1</hbase.version>
+    <hbase.version>1.2.1</hbase.version>
 
-    <compileSource>1.8</compileSource>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <repositories>
@@ -110,18 +111,6 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <configuration>
-            <source>${compileSource}</source>
-            <target>${compileSource}</target>
-            <showWarnings>true</showWarnings>
-            <showDeprecation>false</showDeprecation>
-            <compilerArgument>-Xlint:-options</compilerArgument>
-        </configuration>
-      </plugin>
-
       <!-- Use Ant to configure the appropriate "tcnative.classifier" property -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/java/simple-performance-test/pom.xml
+++ b/java/simple-performance-test/pom.xml
@@ -25,9 +25,10 @@
 
   <properties>
     <bigtable.zone>us-central1-b</bigtable.zone>
-    <bigtable.version>0.2.4</bigtable.version>
-    <hbase.version>1.1.3</hbase.version>
-    <compileSource>1.8</compileSource>
+    <bigtable.version>0.3.0</bigtable.version>
+    <hbase.version>1.2.1</hbase.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <repositories>
@@ -105,18 +106,6 @@
       </extension>
     </extensions>
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <configuration>
-            <source>${compileSource}</source>
-            <target>${compileSource}</target>
-            <showWarnings>true</showWarnings>
-            <showDeprecation>false</showDeprecation>
-            <compilerArgument>-Xlint:-options</compilerArgument>
-        </configuration>
-      </plugin>
-
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>


### PR DESCRIPTION
1. Where possible update HBase to 1.2.1
2. These 4 are tested.
3. gae-flex the gcloud mvm plugin appears to have regressed, so I’m not
yet updating
4. Dataproc-wordcount needs some work
5. dataflow-connector ran into an issue and I’m debugging, a new PR for
that.
dataflow-pardo-helloworld, hello-world, simple-cli, and
simple-performance have been tested and passed.