### PR TITLE
Update Dataflow

### DIFF
--- a/java/dataflow-connector-examples/pom.xml
+++ b/java/dataflow-connector-examples/pom.xml
@@ -27,8 +27,7 @@ limitations under the License.
       -Dbigtable.zone=<your zone>
       -Dbigtable.table=<Table to Read / Write>
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project>
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.google.cloud.bigtable.dataflow</groupId>
@@ -37,16 +36,16 @@ limitations under the License.
   <packaging>jar</packaging>
 
   <properties>
-    <dataflow.version>1.0.0</dataflow.version>
-    <bigtable.version>0.2.4</bigtable.version>
+    <dataflow.version>1.5.1</dataflow.version>
+    <bigtable.version>0.3.0</bigtable.version>
     <!-- For Netty HTTP2/TLS negotiation -->
-    <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>
-    <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
+    <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for dataflow -->
     
     <bigtable.zone>us-central1-b</bigtable.zone>
     <bigtable.table>Dataflow_test</bigtable.table>
     <bigtable.hbase.version>${bigtable.version}</bigtable.hbase.version>
-    <compileSource>1.8</compileSource>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -102,46 +101,29 @@ limitations under the License.
     </dependency>
     <dependency>
         <groupId>com.google.cloud.bigtable</groupId>
-        <artifactId>bigtable-hbase-1.0</artifactId>
-        <version>${bigtable.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>com.google.cloud.bigtable</groupId>
         <artifactId>bigtable-hbase-dataflow</artifactId>
         <version>${bigtable.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork13</version>
+      <classifier>${tcnative.classifier}</classifier>
+    </dependency>
  </dependencies>
 
-  <profiles>
+  <profiles>  <!-- These are only required for runlocal -->
     <profile>
-      <id>jdk7</id>
-        <activation>
-            <jdk>1.7</jdk>
-        </activation>
-        <properties>
-            <alpn.version>${alpn.jdk7.version}</alpn.version>
-        </properties>
+      <id>mac</id>
+      <properties>
+        <tcnative.classifier>osx-x86_64</tcnative.classifier>
+      </properties>      
     </profile>
     <profile>
-        <id>jdk8</id>
-        <activation>
-            <jdk>1.8</jdk>
-        </activation>
-        <properties>
-            <alpn.version>${alpn.jdk8.version}</alpn.version>
-        </properties>
-    </profile>
-
-    <profile>
-      <id>staged</id> 
-      <repositories>
-        <repository>
-          <id>snapshots-repo</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <releases><enabled>false</enabled></releases>
-          <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-      </repositories>
+      <id>windows</id>
+      <properties>
+        <tcnative.classifier>windows-x86_64</tcnative.classifier>
+      </properties>      
     </profile>
 
     <profile>
@@ -160,7 +142,6 @@ limitations under the License.
             <configuration>
               <executable>java</executable>
               <arguments>
-                <argument>-Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar</argument>
                 <argument>-classpath</argument>
                 <classpath/>
                 <argument>com.google.cloud.bigtable.dataflow.example.HelloWorldWrite</argument>
@@ -193,7 +174,6 @@ limitations under the License.
             <configuration>
               <executable>java</executable>
               <arguments>
-                <argument>-Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar</argument>
                 <argument>-classpath</argument>
                 <classpath/>
                 <argument>com.google.cloud.bigtable.dataflow.example.SourceRowCount</argument>
@@ -227,7 +207,6 @@ limitations under the License.
             <configuration>
               <executable>java</executable>
               <arguments>
-                <argument>-Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar</argument>
                 <argument>-classpath</argument>
                 <classpath/>
                 <argument>com.google.cloud.bigtable.dataflow.example.PubsubWordCount</argument>
@@ -251,19 +230,6 @@ limitations under the License.
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.6</version>
         <configuration>
@@ -274,24 +240,7 @@ limitations under the License.
           </archive>
         </configuration>
       </plugin>
-      
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-            <source>${compileSource}</source>
-            <target>${compileSource}</target>
-            <showWarnings>true</showWarnings>
-            <showDeprecation>false</showDeprecation>
-            <compilerArgument>-Xlint:-options</compilerArgument>
-        </configuration>
-      </plugin>
-      
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
-      </plugin>
+
     </plugins>
   </build>
 

--- a/java/dataflow-import-examples/pom.xml
+++ b/java/dataflow-import-examples/pom.xml
@@ -9,21 +9,24 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <bigtable.hbase.version>0.2.4</bigtable.hbase.version>
+    <bigtable.hbase.version>0.3.0</bigtable.hbase.version>
     <!-- For Netty HTTP2/TLS negotiation -->
-    <alpn.jdk7.version>7.1.3.v20150130</alpn.jdk7.version>
-    <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
+    <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for dataflow -->
 
     <bigtable.project>bigtable_project_id</bigtable.project>
     <bigtable.cluster>bigtable_cluster_id</bigtable.cluster>
     <bigtable.zone>bigtable_zone</bigtable.zone>
     <bigtable.table>bigtable_table_name</bigtable.table>
     <dataflow.project>${bigtable.project}</dataflow.project>
+    
     <dataflow.staging.location>gs://staging_folder_name</dataflow.staging.location>
     <file.pattern>name_or_prefix_of_data_file</file.pattern>
     <dataflow.runner>BlockingDataflowPipelineRunner</dataflow.runner>
     <sequencefile.format.094>false</sequencefile.format.094>
-    <compileSource>1.7</compileSource>
+
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -77,27 +80,15 @@
       <artifactId>bigtable-dataflow-import</artifactId>
       <version>${bigtable.hbase.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork13</version>
+      <classifier>${tcnative.classifier}</classifier>
+    </dependency>
   </dependencies>
 
   <profiles>
-    <profile>
-      <id>jdk7</id>
-      <activation>
-        <jdk>1.7</jdk>
-      </activation>
-      <properties>
-        <alpn.version>${alpn.jdk7.version}</alpn.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <properties>
-        <alpn.version>${alpn.jdk8.version}</alpn.version>
-      </properties>
-    </profile>
     <profile>
       <id>ImportByDataflow</id>
       <activation>
@@ -114,7 +105,6 @@
             <configuration>
               <executable>java</executable>
               <arguments>
-                <argument>-Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar</argument>
                 <argument>-classpath</argument>
                 <classpath/>
                 <argument>com.google.cloud.bigtable.dataflow.example.ImportByDataflow</argument>
@@ -139,44 +129,4 @@
       </build>
     </profile>
   </profiles>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>${compileSource}</source>
-          <target>${compileSource}</target>
-          <showWarnings>true</showWarnings>
-          <showDeprecation>false</showDeprecation>
-          <compilerArgument>-Xlint:-options</compilerArgument>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/java/dataflow-pardo-helloworld/pom.xml
+++ b/java/dataflow-pardo-helloworld/pom.xml
@@ -22,9 +22,11 @@ permissions and limitations under the License.
   <packaging>jar</packaging>
 
   <properties>
-    <dataflow.version>1.0.0</dataflow.version>
-    <bigtable.version>0.2.4</bigtable.version>
+    <dataflow.version>1.5.1</dataflow.version>
+    <bigtable.version>0.3.0</bigtable.version>
     <compileSource>1.8</compileSource>
+    <!-- For Netty HTTP2/TLS negotiation -->
+    <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for dataflow -->
 
     <bigtable.hbase.version>${bigtable.version}</bigtable.hbase.version>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -80,43 +82,22 @@ permissions and limitations under the License.
   </pluginRepositories>
 
   <dependencies>
-        <dependency>
-            <groupId>com.google.cloud.dataflow</groupId>
-            <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-            <version>${dataflow.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.cloud.bigtable</groupId>
-            <artifactId>bigtable-hbase-1.0</artifactId>
-            <version>${bigtable.version}</version>
-        </dependency>
+    <dependency>
+        <groupId>com.google.cloud.dataflow</groupId>
+        <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
+        <version>${dataflow.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>com.google.cloud.bigtable</groupId>
+        <artifactId>bigtable-hbase-dataflow</artifactId>
+        <version>${bigtable.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork13</version>
+      <classifier>${tcnative.classifier}</classifier>
+    </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <mainClass>com.example.bigtable.sample.WordCountDriver</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
1. Dataflow no longer requires (or likes) bigtable-hbase-1.0
2. Use Netty-TCNative-boringSSL for Dataflow.
3. Remove cruft