### PR TITLE
Fix flake8 errors in Python REST sample.

### DIFF
--- a/python/rest/.gitignore
+++ b/python/rest/.gitignore
@@ -1,0 +1,1 @@
+rest_env

--- a/python/rest/README.md
+++ b/python/rest/README.md
@@ -61,7 +61,8 @@ which creates a virtual Python environment:
 
 ## Instructions
 
-* `put_get.py` demonstrates some simple operations directly using requests.
+* `put_get.py` demonstrates some simple operations directly using requests. You
+  must create the test table `some-table2` with column family `cf` first.
 
 * `put_get_with_client.py` uses `rest_client.py` to wrap some of the details
 in methods, as well as creating the table `new-table5001` if it doesn't exist.

--- a/python/rest/put_get.py
+++ b/python/rest/put_get.py
@@ -27,11 +27,12 @@ put_get_with_client.py
 """
 
 import base64
+from collections import OrderedDict
 import json
 import random
-import requests
-from collections import OrderedDict
 from string import ascii_uppercase, digits
+
+import requests
 
 # Use localhost, change IP to external IP of REST server if running on remote
 # client. use gcloud compute firewall-rules to open firewall rules
@@ -47,7 +48,7 @@ row_key = ''.join(random.choice(ascii_uppercase + digits) for _ in range(10))
 column = "cf:count"
 value = "hello world"
 
-#HBase REST interface requires all these values be encoded.
+# HBase REST interface requires all these values be encoded.
 rowKeyEncoded = base64.b64encode(row_key)
 encodedColumn = base64.b64encode(column)
 encodedValue = base64.b64encode(value)
@@ -81,7 +82,7 @@ assert got_value == value
 
 
 # now we can delete the value
-requests.delete(base_url + "/" + table_name + "/" +row_key)
+requests.delete(base_url + "/" + table_name + "/" + row_key)
 
 # verify we now get a 404 when attempting to GET the value
 request = requests.get(base_url + "/" + table_name + "/" + row_key,

--- a/python/rest/put_get_with_client.py
+++ b/python/rest/put_get_with_client.py
@@ -24,8 +24,8 @@ creating the table if it doesn't exist
 
 import random
 from string import ascii_uppercase, digits
+
 import rest_client
-import sys
 
 # Use localhost, change IP to external IP of REST server if running on remote
 # client. use gcloud compute firewall-rules to open firewall rules

--- a/python/rest/requirements.txt
+++ b/python/rest/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.10.0

--- a/python/rest/rest_client.py
+++ b/python/rest/rest_client.py
@@ -17,6 +17,7 @@
 import base64
 from collections import OrderedDict
 import json
+
 import requests
 
 
@@ -59,13 +60,13 @@ class HbaseRestClient(object):
         ])
         rows = [cell]
         json_output = {"Row": rows}
-        r = requests.post(self.base_url + "/" + self.table_name + "/" + row_key,
-                          data=json.dumps(json_output),
-                          headers={
-                              "Content-Type": "application/json",
-                              "Accept": "application/json",
-                          }
-                          )
+        r = requests.post(
+            self.base_url + "/" + self.table_name + "/" + row_key,
+            data=json.dumps(json_output),
+            headers={
+               "Content-Type": "application/json",
+               "Accept": "application/json",
+            })
         if r.status_code != 200:
             print "got status code %d when putting" % r.status_code
 


### PR DESCRIPTION
This is one of the steps in getting ready to enable automated tests for the Python samples.

I will have a similar PR for the thrift directory, but I haven't had time to manually test that code yet.