### PR TITLE
Fix flake8 errors in Python Thrift sample.

### DIFF
--- a/python/thrift/client.py
+++ b/python/thrift/client.py
@@ -17,13 +17,13 @@
 
 
 import sys
-sys.path.append('gen-py')
+sys.path.append('gen-py')  # noqa
 
-from thrift.transport import TSocket
-from thrift.protocol import TBinaryProtocol
-from thrift.transport import TTransport
-from thrift import Thrift
 from hbase import Hbase
+from thrift import Thrift
+from thrift.protocol import TBinaryProtocol
+from thrift.transport import TSocket
+from thrift.transport import TTransport
 
 
 class ThriftClient(object):
@@ -63,11 +63,15 @@ class ThriftClient(object):
             print '%s' % tx.message
 
     def put_row(self, table, row_key, column, value):
-        """ Puts a value in a specific cell in Hbase based on table name, row key, and the full column name
+        """ Puts a value in a specific cell in Hbase based on table name, row
+        key, and the full column name
+
         :param table:
         :param row_key: The key of the row we want to put a value in
-        :param column: The column name including the column family with the colon format, such as 'cf:count'
-        :param value: The array of bytes (using Python's string type) to insert as the value for this cell
+        :param column: The column name including the column family with the
+                       colon format, such as 'cf:count'
+        :param value: The array of bytes (using Python's string type) to insert
+                      as the value for this cell
         :return: None
         """
         try:
@@ -78,10 +82,13 @@ class ThriftClient(object):
             print '%s' % tx.message
 
     def delete_column(self, table, row_key, column):
-        """ Deletes a column from a row in the table. If it's the last remaining column it will also delete the row.
+        """ Deletes a column from a row in the table. If it's the last remaining
+        column it will also delete the row.
+
         :param table: The name of the table
         :param row_key: The key of the row we want to put a value in
-        :param column: The column name including the column family with the colon format, such as 'cf:count'
+        :param column: The column name including the column family with the
+                       colon format, such as 'cf:count'
         :return: None
         """
         try:

--- a/python/thrift/flask_thrift.py
+++ b/python/thrift/flask_thrift.py
@@ -15,12 +15,13 @@
 # limitations under the License.
 #
 
-from flask import Flask, request
-
-app = Flask(__name__)
+import struct
 
 from client import ThriftClient
-import struct
+from flask import Flask, request
+
+
+app = Flask(__name__)
 
 
 def _encode_int(n):
@@ -43,7 +44,8 @@ def _decode_int(s):
     return struct.unpack('>i', s)[0]
 
 
-@app.route('/<table>/<key>/<column>/<type_>', methods=['GET', 'POST', 'DELETE'])
+@app.route(
+    '/<table>/<key>/<column>/<type_>', methods=['GET', 'POST', 'DELETE'])
 def get(table, key, column, type_):
     """
     Handle our incoming REST requests to interface with Bigtable.

--- a/python/thrift/requirements.txt
+++ b/python/thrift/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.10.1
 itsdangerous==0.24
-Jinja2==2.7.3
+Jinja2==2.8
 MarkupSafe==0.23
-Werkzeug==0.10.4
-requests
+Werkzeug==0.11.9
+requests==2.10.0

--- a/python/thrift/test.py
+++ b/python/thrift/test.py
@@ -16,15 +16,18 @@
 #
 
 import random
-import requests
 import string
 
-# Create a random row key to minimize chances of intersecting with other clients
-row_key = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+import requests
+
+# Create a random row key to minimize chances of intersecting with other
+# clients.
+row_key = ''.join(
+    random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
 
 # First we build a URL assuming some-table2 exists, using the random
 # row key, the column cf:count, and we specify the 'str' type
-# so our strings are directly store
+# so our strings are directly store.
 url = 'http://localhost:5000/some-table2/%s/cf:count/str' % row_key
 r = requests.get(url)
 assert r.text == "Not found"
@@ -38,10 +41,11 @@ r = requests.get(url)
 assert r.text == "Not found"
 
 
-# repeat process for ints
-# note that int types are still strings at the HTTP layer, the last section of the URL
-# that we want to serialize the data we pass in now as an int
-row_key = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+# Repeat the process for ints.
+# Note that int types are still strings at the HTTP layer, the last section of
+# the URL that we want to serialize the data we pass in now as an int.
+row_key = ''.join(
+    random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
 
 url = 'http://localhost:5000/some-table2/%s/cf:count/int' % row_key
 r = requests.get(url)
@@ -56,4 +60,3 @@ r = requests.get(url)
 assert r.text == "Not found"
 
 print "Done testing."
-


### PR DESCRIPTION
I manually tested these on a new GCE instance. Note: The readme claims
the Thrift sample only works on GCE so I did not try to test on my
workstation.