### PR TITLE
Use HBase 1.2 uniformly across quickstart

### DIFF
--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -77,7 +77,7 @@
   <dependencies>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-1.1</artifactId>
+      <artifactId>bigtable-hbase-1.2</artifactId>
       <version>${bigtable.version}</version>
     </dependency>
 

--- a/quickstart/src/main/resources/hbase-site.xml
+++ b/quickstart/src/main/resources/hbase-site.xml
@@ -26,6 +26,6 @@
   <property><name>google.bigtable.zone.name</name><value>${bigtable.zone}</value></property>
   <property>
     <name>hbase.client.connection.impl</name>
-    <value>com.google.cloud.bigtable.hbase1_1.BigtableConnection</value>
+    <value>com.google.cloud.bigtable.hbase1_2.BigtableConnection</value>
   </property>
 </configuration>


### PR DESCRIPTION
Previously we used HBase 1.2 but used the hbase-bigtable-1.1. This updates everything to 1.2. This is needed as some parts of the thirdparty depend on 1.2.