### PR TITLE
Update QuickStart to use mvm:java and disambiguate

### DIFF
--- a/java/dataproc-wordcount/pom.xml
+++ b/java/dataproc-wordcount/pom.xml
@@ -22,7 +22,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dataproc.cluster>dp</dataproc.cluster>
     <bigtable.projectID>YOUR_PROJECT_ID_HERE</bigtable.projectID>
     <bigtable.clusterID>YOUR_CLUSTER_ID_HERE</bigtable.clusterID>
     <bigtable.zone>us-central1-b</bigtable.zone>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -142,19 +142,18 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <executable>java</executable>
+          <mainClass>org.jruby.Main</mainClass>
           <arguments>
-            <argument>-Xms512m</argument>
-            <argument>-Xmx2048m</argument>
-            <argument>-XX:+UseConcMarkSweepGC</argument>
-            <argument>-Dhbase.ruby.sources=thirdparty/ruby</argument>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>org.jruby.Main</argument>
             <argument>-d</argument>
             <argument>-X+O</argument>
             <argument>thirdparty/hirb.rb</argument>
           </arguments>
+          <systemProperties>
+            <systemProperty>
+              <key>hbase.ruby.sources</key>
+              <value>thirdparty/ruby</value>
+            </systemProperty>
+          </systemProperties>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
1. Disambiguation for Clusters & Projects
2. Use exec:java to use less memory.  Fixes issue on DevShell hanging, I'm not
releasing as there are scary errors on exit
3. dataproc-wordcount/pom no longer needs to know a cluster name.

@sduskis @hegemonic FYI