### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/java/gae-flexible-helloworld/README.md
+++ b/java/gae-flexible-helloworld/README.md
@@ -77,7 +77,7 @@ exit
 The first thing to do, if you'd like to debug is use the `servlet.log()` methods, they seem to work when other loggers don't.  Then take control of your GAE instance:
 
 1. Find your instance
-  `gcloud preview app modules list`
+  `gcloud app modules list`
 
 1. [Connect to an instance with ssh](https://cloud.google.com/appengine/docs/flexible/java/connecting-to-an-instance-with-ssh)
 

--- a/java/jetty-managed-vm/README.md
+++ b/java/jetty-managed-vm/README.md
@@ -107,7 +107,7 @@ This describes a [Jetty](http://www.eclipse.org/jetty/) based [Servlet](http://w
 
 1. Deploy the application
 
- `gcloud preview app deploy app.yaml --docker-build=remote`
+ `gcloud app deploy app.yaml --docker-build=remote`
 
 1. go to the new default module which will be displayed in results from the deploy.  It will look like: `https://20150624t111224-dot-default-dot-PROJECTID.appspot.com` 
 

--- a/python/thrift/appengine-ssl-gateway/appengine/Makefile
+++ b/python/thrift/appengine-ssl-gateway/appengine/Makefile
@@ -31,7 +31,7 @@ KEY_FILE = stunnel.pem
 # step.
 deploy: env_project_id
 	$(VERB) if ! [ -e $(KEY_FILE) ]; then echo >&2 "$(KEY_FILE) missing"; exit 1; fi
-	$(VERB) gcloud preview app deploy app.yaml \
+	$(VERB) gcloud app deploy app.yaml \
 	            --project $$PROJECT_ID --version thrift-gateway --no-promote
 
 clean:


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.