### PR TITLE
Update client to 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ There are many examples / sample / demo programs here, each with its own README.
 
 <!-- Comment out 'til I can update to Dataproc and more.
 ## Scala / Spark
-* [PubSub](https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/tree/master/scala/spark-pubsub) – Integrating Spark Streaming with Cloud Pubsub
 * [Standalone-Wordcount](https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/tree/master/scala/spark-standalone-wordcount) – Simple Spark job that counts the number of times a word appears in a text file
+* [PubSub](https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/tree/master/scala/spark-pubsub) – Integrating Spark Streaming with Cloud Pubsub
 * [Streaming-Wordcount](https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/tree/master/scala/spark-streaming-wordcount) – Pulls new files from a GCS directory every 30 seconds and perform a simple Spark job that counts the number of times a word appears in each new file
  -->
 

--- a/java/dataflow-connector-examples/pom.xml
+++ b/java/dataflow-connector-examples/pom.xml
@@ -36,10 +36,8 @@ limitations under the License.
 
   <properties>
     <dataflow.version>1.5.1</dataflow.version>
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <!-- For Netty HTTP2/TLS negotiation -->
-    <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for dataflow -->
     
     <bigtable.table>Dataflow_test</bigtable.table>
     <pubsubTopic>projects/${bigtable.projectID}/topics/shakes</pubsubTopic>
@@ -107,8 +105,7 @@ limitations under the License.
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${tcnative.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
 
     <dependency>
@@ -125,19 +122,6 @@ limitations under the License.
  </dependencies>
 
   <profiles>  <!-- These are only required for runlocal -->
-    <profile>
-      <id>mac</id>
-      <properties>
-        <tcnative.classifier>osx-x86_64</tcnative.classifier>
-      </properties>      
-    </profile>
-    <profile>
-      <id>windows</id>
-      <properties>
-        <tcnative.classifier>windows-x86_64</tcnative.classifier>
-      </properties>      
-    </profile>
-
     <profile>
       <id>Test</id>
         <activation>

--- a/java/dataflow-import-examples/pom.xml
+++ b/java/dataflow-import-examples/pom.xml
@@ -23,14 +23,12 @@ permissions and limitations under the License.
   <url>http://maven.apache.org</url>
 
   <properties>
-    <bigtable.hbase.version>0.9.0</bigtable.hbase.version>
+    <bigtable.hbase.version>0.9.1</bigtable.hbase.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <!-- For Netty HTTP2/TLS negotiation -->
-    <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for dataflow -->
 
     <bigtable.project>bigtable_project_id</bigtable.project>
     <bigtable.cluster>bigtable_cluster_id</bigtable.cluster>
-    <bigtable.zone>bigtable_zone</bigtable.zone>
+
     <bigtable.table>bigtable_table_name</bigtable.table>
     <dataflow.project>${bigtable.project}</dataflow.project>
     
@@ -98,8 +96,7 @@ permissions and limitations under the License.
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${tcnative.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
 
     <dependency>

--- a/java/dataflow-pardo-helloworld/README.md
+++ b/java/dataflow-pardo-helloworld/README.md
@@ -30,7 +30,7 @@ pipeline that writes the words "Hello" and "World" into Cloud Bigtable.
     
 ## Run via maven
 
-`$ mvn compile exec:java -Dexec.mainClass="com.example.bigtable.dataflow.pardo.HelloWorldBigtablePardo" -Dexec.args="--runner=BlockingDataflowPipelineRunner --project=<PROJECTID> --bigtableProjectId=<PROJECTID> --bigtableInstanceId=<InstanceID> --bigtableTableId=Dataflow_test --stagingLocation=gs://<STORAGE_BUCKET>/staging"`
+`$ mvn package exec:exec -Dbigtable.projectID=PROJECT -Dbigtable.instanceID=INSTANCE -Dgs=gs://BUCKET`
 
 ### Verify
 

--- a/java/dataflow-pardo-helloworld/pom.xml
+++ b/java/dataflow-pardo-helloworld/pom.xml
@@ -23,14 +23,12 @@ permissions and limitations under the License.
 
   <properties>
     <dataflow.version>1.5.1</dataflow.version>
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
     <slf4j.version>1.7.21</slf4j.version>
     
     <bigtable.table>Dataflow_test</bigtable.table>
 
     <compileSource>1.8</compileSource>
-    <!-- For Netty HTTP2/TLS negotiation -->
-    <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for dataflow -->
 
     <bigtable.hbase.version>${bigtable.version}</bigtable.hbase.version>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -99,8 +97,7 @@ permissions and limitations under the License.
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${tcnative.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
 
     <dependency>

--- a/java/dataproc-wordcount/pom.xml
+++ b/java/dataproc-wordcount/pom.xml
@@ -25,7 +25,7 @@
     <bigtable.projectID>YOUR_PROJECT_ID_HERE</bigtable.projectID>
     <bigtable.instanceID>YOUR_INSTANCE_ID_HERE</bigtable.instanceID>
 
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
     <hbase.version>1.2.1</hbase.version><!-- may need to match Dataproc HBase version -->
     <hbase.if>1.2</hbase.if> <!-- hbase interface - it changed between 1.0 and 1.1.x -->
 
@@ -90,17 +90,15 @@
       <artifactId>hbase-client</artifactId>
       <version>${hbase.version}</version>
     </dependency>
-<!-- 
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-server</artifactId>
-      <version>${hbase.version}</version>
-    </dependency>
- -->
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-${hbase.if}</artifactId>
       <version>${bigtable.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork19</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>

--- a/java/gae-flexible-helloworld/README.md
+++ b/java/gae-flexible-helloworld/README.md
@@ -7,8 +7,6 @@ This app provides:
 1. A web interface that uses Cloud Bigtable to track the number of visits from an opaque version of your Google account.
 1. A simple REST interface that can read and write arbitrary data to a Cloud Bigtable table using GET, POST, and DELETE verbs.
 
-**SECURITY WARNING** – This app will read / write the two tables you create (**`gae-hello`** and **`from-json`**) The app provides NO ADDITIONAL SECURITY PROTECTIONS. We suggest that instances should only be available while testing and that test data be used.
-
 ## Table of Contents
 1. [Requirements](#Requirements)
 1. [Project Setup](#Project-Setup)
@@ -55,7 +53,7 @@ exit
 
 1. Build and run the Project
 
-    `mvn clean gcloud:run -Pmac  -Dbigtable.projectID=myProject -Dbigtable.instanceID=myInstance `
+    `mvn clean gcloud:run -Dbigtable.projectID=myProject -Dbigtable.instanceID=myInstance `
 
     NOTE - The `-Pmac` is REQUIRED for running on a Macintosh, `-Pwindows` is used for running on Windows, and the option is not required for Linux.
 

--- a/java/gae-flexible-helloworld/pom.xml
+++ b/java/gae-flexible-helloworld/pom.xml
@@ -25,7 +25,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
     <hbase.version>1.2.1</hbase.version>
     <bigtable.projectID>YOUR_PROJECT_ID</bigtable.projectID>
     <bigtable.instanceID>YOUR_INSTANCE_ID</bigtable.instanceID>
@@ -33,10 +33,8 @@
     <hadoop.version>2.4.1</hadoop.version>
     <compat.module>hbase-hadoop2-compat</compat.module>
 
-    <appengine.version>1.9.38</appengine.version>
+    <appengine.version>1.9.40</appengine.version>
     <gcloud.plugin.version>2.0.9.111.v20160527</gcloud.plugin.version>
-    
-    <tcnative.classifier>linux-x86_64</tcnative.classifier> <!-- default for MVMs -->
 
     <slf4j.version>1.7.12</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
@@ -115,8 +113,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${tcnative.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
 
     <dependency>
@@ -132,21 +129,6 @@
 	    <version>20140107</version>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>mac</id>
-      <properties>
-        <tcnative.classifier>osx-x86_64</tcnative.classifier>
-      </properties>      
-    </profile>
-    <profile>
-      <id>windows</id>
-      <properties>
-        <tcnative.classifier>windows-x86_64</tcnative.classifier>
-      </properties>      
-    </profile>
-  </profiles>
 
   <build>
     <outputDirectory>target/${project.artifactId}-${project.version}/WEB-INF/classes</outputDirectory> 

--- a/java/hello-world/README.md
+++ b/java/hello-world/README.md
@@ -9,6 +9,7 @@ explanation of the code.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Downloading the sample](#downloading-the-sample)
@@ -134,17 +135,10 @@ application.
 
 ## Running the application
 
-Set the following environment variables or replace them with the appropriate
-values in the `mvn` commands below. Set:
-
-+   `GCLOUD_PROJECT` to the project ID,
-+   `BIGTABLE_INSTANCE` to the Bigtable cluster ID,
-
 Build and run the sample using Maven.
 
     mvn package
-    mvn exec:java -Dbigtable.projectID=${GCLOUD_PROJECT} \
-        -Dbigtable.instanceID=${BIGTABLE_INSTANCE}
+    mvn exec:java -Dbigtable.projectID=GCLOUDPROJECT -Dbigtable.instanceID=BIGTABLEINSTANCE
 
 You will see output resembling the following, interspersed with informational logging
 from the underlying libraries:

--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -25,7 +25,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
     <hbase.version>1.1.5</hbase.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -91,22 +91,12 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${os.detected.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
   </dependencies>
 
 
   <build>
-    <extensions>
-      <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.0.Final</version>
-      </extension>
-    </extensions>
-
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/java/simple-cli/pom.xml
+++ b/java/simple-cli/pom.xml
@@ -11,9 +11,8 @@
   <properties>
     <bigtable.projectID>YOUR_PROJECT_ID</bigtable.projectID>
     <bigtable.instanceID>YOUR_INSTANCE_ID</bigtable.instanceID>
-    <bigtable.zone>us-central1-b</bigtable.zone>
 
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
 
     <hbase.version>1.2.1</hbase.version>
 
@@ -87,21 +86,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${os.detected.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
   </dependencies>
 
   <build>
-    <extensions>
-      <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.0.Final</version>
-      </extension>
-    </extensions>
-
     <resources>
       <resource>
         <directory>src/main/resources</directory>
@@ -109,30 +98,6 @@
       </resource>
     </resources>
     <plugins>
-      <!-- Use Ant to configure the appropriate "tcnative.classifier" property -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target>
-                <condition property="tcnative.classifier"
-                           value="${os.detected.classifier}-fedora"
-                           else="${os.detected.classifier}">
-                  <isset property="os.detected.release.fedora"/>
-                </condition>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>

--- a/java/simple-performance-test/pom.xml
+++ b/java/simple-performance-test/pom.xml
@@ -24,7 +24,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
     <hbase.version>1.2.1</hbase.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -90,20 +90,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${os.detected.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
   </dependencies>
 
   <build>
-    <extensions>
-      <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.1.Final</version>
-      </extension>
-    </extensions>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -36,7 +36,7 @@ Alternatively you can just use maven directly.
 
     HBase Shell; enter 'help<RETURN>' for list of supported commands.
     Type "exit<RETURN>" to leave the HBase Shell
-    Version 1.1.1, rd0a115a7267f54e01c72c603ec53e91ec418292f, Tue Jun 23 14:56:34 PDT 2015
+    Version 1.2.1, rd0a115a7267f54e01c72c603ec53e91ec418292f, Tue Jun 23 14:56:34 PDT 2015
 
     hbase(main):001:0>
 

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -23,7 +23,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <bigtable.version>0.9.0</bigtable.version>
+    <bigtable.version>0.9.1</bigtable.version>
     <hbase.version>1.2.1</hbase.version> <!-- Be sure to update thirdparty when you change this -->
     <bigtable.connection>com.google.cloud.bigtable.hbase1_2.BigtableConnection</bigtable.connection>
 
@@ -90,8 +90,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork13</version>
-      <classifier>${os.detected.classifier}</classifier>
+      <version>1.1.33.Fork19</version>
     </dependency>
   </dependencies>
 
@@ -103,40 +102,7 @@
       </resource>
     </resources>
 
-    <extensions>
-      <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.0.Final</version>
-      </extension>
-    </extensions>
-
    <plugins>
-      <!-- Use Ant to configure the appropriate "tcnative.classifier" property -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target>
-                <condition property="tcnative.classifier"
-                           value="${os.detected.classifier}-fedora"
-                           else="${os.detected.classifier}">
-                  <isset property="os.detected.release.fedora"/>
-                </condition>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
1. Samples now use netty tcnative-boringssl-static Fork19 ‘UberJar’
2. UberJar means that we don’t need to figure out which tcnative to use.
3. pom’s and README’s got a bit simpler.
4. An error in the dataflow-partdo-helloworld README.md was fixed.