### PR TITLE
Fix lint errors and updated requirements.

### DIFF
--- a/python/thrift/client.py
+++ b/python/thrift/client.py
@@ -19,11 +19,11 @@
 import sys
 sys.path.append('gen-py')  # noqa
 
-from hbase import Hbase
-from thrift import Thrift
-from thrift.protocol import TBinaryProtocol
-from thrift.transport import TSocket
-from thrift.transport import TTransport
+from hbase import Hbase  # noqa
+from thrift import Thrift  # noqa
+from thrift.protocol import TBinaryProtocol  # noqa
+from thrift.transport import TSocket  # noqa
+from thrift.transport import TTransport  # noqa
 
 
 class ThriftClient(object):

--- a/python/thrift/requirements.txt
+++ b/python/thrift/requirements.txt
@@ -1,6 +1,6 @@
-Flask==0.10.1
+Flask==0.11.1
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
-Werkzeug==0.11.9
+Werkzeug==0.11.10
 requests==2.10.0


### PR DESCRIPTION
New version of flake8 needs the imports below the path addition to also
have a comment to ignore them for the linter.

@lesv PTAL. This should make Travis happy.