### PR TITLE
Updating to cloud bigtable client 0.9.4.

### DIFF
--- a/java/dataflow-connector-examples/pom.xml
+++ b/java/dataflow-connector-examples/pom.xml
@@ -47,7 +47,7 @@ limitations under the License.
 
   <properties>
     <dataflow.version>1.8.0</dataflow.version>
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
     <slf4j.version>1.7.21</slf4j.version>
 
     <bigtable.table>Dataflow_test</bigtable.table>

--- a/java/dataflow-import-examples/pom.xml
+++ b/java/dataflow-import-examples/pom.xml
@@ -30,7 +30,7 @@ permissions and limitations under the License.
   </parent>
 
   <properties>
-    <bigtable.hbase.version>0.9.3</bigtable.hbase.version>
+    <bigtable.hbase.version>0.9.4</bigtable.hbase.version>
     <slf4j.version>1.7.21</slf4j.version>
 
     <bigtable.projectID>bigtable_project_id</bigtable.projectID>

--- a/java/dataproc-wordcount/pom.xml
+++ b/java/dataproc-wordcount/pom.xml
@@ -35,7 +35,7 @@
     <bigtable.projectID>YOUR_PROJECT_ID_HERE</bigtable.projectID>
     <bigtable.instanceID>YOUR_INSTANCE_ID_HERE</bigtable.instanceID>
 
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
     <hbase.version>1.2.1</hbase.version><!-- may need to match Dataproc HBase version -->
     <hbase.if>1.2</hbase.if> <!-- hbase interface - it changed between 1.0 and 1.1.x -->
 

--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -32,7 +32,7 @@
   </parent>
 
   <properties>
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
     <hbase.version>1.1.5</hbase.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/java/simple-cli/pom.xml
+++ b/java/simple-cli/pom.xml
@@ -22,7 +22,7 @@
     <bigtable.projectID>YOUR_PROJECT_ID</bigtable.projectID>
     <bigtable.instanceID>YOUR_INSTANCE_ID</bigtable.instanceID>
 
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
 
     <hbase.version>1.2.1</hbase.version>
 

--- a/java/simple-performance-test/pom.xml
+++ b/java/simple-performance-test/pom.xml
@@ -34,7 +34,7 @@
   </parent> -->
 
   <properties>
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
     <hbase.version>1.2.1</hbase.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -23,7 +23,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
     <hbase.version>1.2.1</hbase.version> <!-- Be sure to update thirdparty when you change this -->
     <bigtable.connection>com.google.cloud.bigtable.hbase1_2.BigtableConnection</bigtable.connection>
 


### PR DESCRIPTION
0.9.3 had major problems due to a netty bug.  0.9.4 fixes that plus a whole bunch of other things.