### PR TITLE
Fix the Travis build configuration.

### DIFF
--- a/python/thrift/flask_thrift.py
+++ b/python/thrift/flask_thrift.py
@@ -107,6 +107,7 @@ def _delete_column(table, row_key, column):
     with ThriftClient() as client:
         client.delete_column(table, row_key, column)
 
+
 # set debug=True in the run() call to see better debugging messages
 if __name__ == '__main__':
     app.run()

--- a/travis.sh
+++ b/travis.sh
@@ -42,7 +42,8 @@ use_java() {
       echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | \
           sudo debconf-set-selections
       add_ppa 'ppa:webupd8team/java'
-      sudo apt-get -qqy install oracle-java8-installer
+      sudo apt-get -o Dpkg::Options::="--force-overwrite" -qqy install \
+          oracle-java8-installer
       export PATH=/usr/lib/jvm/java-8-oracle/bin:$PATH
       ;;
   esac


### PR DESCRIPTION
Two problems were preventing the Travis build from passing:

1. An update in flake8 caught an issue where we weren't separating top-level definitions by two newlines.
2. The Oracle Java installer stalled waiting for confirmation on overwriting a configuration file.

This PR should fix both issues.

@lesv PTAL