### PR TITLE
Update cluster.sh

### DIFF
--- a/java/dataproc-wordcount/cluster.sh
+++ b/java/dataproc-wordcount/cluster.sh
@@ -85,7 +85,7 @@ start)  # start [<clusterName>]
   TARGET="WordCount-$(date +%s)"
   gcloud dataproc jobs submit hadoop --cluster "$CLUSTER" \
     --jar target/wordcount-mapreduce-0-SNAPSHOT-jar-with-dependencies.jar \
-    wordcount-hbase \
+    -- wordcount-hbase \
     gs://lesv-big-public-data/books/book \
     gs://lesv-big-public-data/books/b10 \
     gs://lesv-big-public-data/books/b100 \


### PR DESCRIPTION
Got below errors when submit the job:
$ ./cluster.sh start 
ERROR: (gcloud.beta.dataproc.jobs.submit.hadoop) unrecognized arguments:
  wordcount-hbase
  gs://lesv-big-public-data/books/book
  gs://lesv-big-public-data/books/b10
  gs://lesv-big-public-data/books/b100
  gs://lesv-big-public-data/books/b1232
  gs://lesv-big-public-data/books/b6130
  WordCount-1491281728
Output table is: WordCount-1491281728

The aliased gcloud command seems missed "--" flag[1].
```
The '--' argument must be specified between gcloud specific args on the left and JOB_ARGS on the right.
```
[1] https://cloud.google.com/sdk/gcloud/reference/beta/dataproc/jobs/submit/hadoop