### PR TITLE
Add Spark Scala Dataproc Wordcount Example

### DIFF
--- a/scala/spark/wordcount/README.md
+++ b/scala/spark/wordcount/README.md
@@ -1,0 +1,102 @@
+# Dataproc Bigtable WordCount Sample
+
+## Overview
+
+This sample demonstrates how to use  [Google Cloud Dataproc](http://cloud.google.com/dataproc), which
+provides a managed [Apache Spark](https://spark.apache.org/) environment with
+[Google Cloud Bigtable](http://cloud.google.com/bigtable/docs).
+
+This specific example provides the classic map reduce example of counting words
+in a text file.
+
+## Prerequisites
+
+1. A [Google Cloud project](console.cloud.google.com) with billing enabled. Please
+be aware of [Bigtable](https://cloud.google.com/bigtable/pricing)
+and [Dataproc](https://cloud.google.com/dataproc/docs/resources/pricing) pricing.
+
+1. You have the [Google Cloud SDK](https://cloud.google.com/sdk/) installed.
+
+1. You have [Scala](https://www.scala-lang.org/) installed.
+
+1. You have basic familiarity with Spark and Scala. It may be helpful to
+install Spark locally.
+
+1. You have [Maven](https://maven.apache.org/) installed.
+
+## Create a Cloud Bigtable Instance
+
+If you don't already have a Cloud Bigtable instance, create one
+
+     gcloud bigtable instances create test-instance --cluster test-cluster --cluster-zone us-east1-b --cluster-num-nodes 3
+
+## Create a Cloud Dataproc Cluster
+
+Create a Cloud DataProc instance:
+
+    gcloud dataproc clusters create spark-cluster
+
+## Build the jar
+
+The Spark job is assembled into a fat jar with all its dependencies. To build, run
+
+   mvn assembly:assembly
+
+## Test your job locally (optional but recommended)
+
+This step requires a local Spark installation.
+
+While you will need a real Bigtable cluster, you can test the Spark job locally,
+if you have Spark insatlled. For testing, consider a Bigtable development
+cluster.
+
+    spark-submit --master local --class com.example.bigtable.spark.wordcount.WordCount \
+    target/cloud-bigtable-dataproc-spark-wordcount-0.1-jar-with-dependencies.jar \
+     your-project-id your-bigtable-instance-id wordcount-scratch \
+     src/test/resources/countme.txt
+
+The job will create the table specified (here, `wordcount`) if it doesn't already exist.
+
+## Submit your job to Dataproc
+
+### Create a Google Cloud Storage bucket
+
+For deployed jobs on Cloud Dataproc, it's easiest to read a file from Google
+Cloud Storage. You can use `gsutil` to create the bucket.
+
+    gsutil mb gs://your-unique-bucket-id
+
+Once done, upload the sample file (or a file of your choice) to the bucket:
+
+    gsutil cp src/test/resources/countme.txt gs://your-unique-bucket-id
+
+### Submit the job to Cloud Dataproc
+
+Now submit your job to Cloud Dataproc:
+
+    gcloud dataproc jobs submit spark --cluster spark-cluster \
+    --class com.example.bigtable.spark.wordcount.WordCount  \
+    --jar target/cloud-bigtable-hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar \
+    -- your-project-id your-bigtable-instance-id wordcountproc gs://your-bucket-id/countme.txt
+
+## Clean up resources
+
+If you don't want to be charged for continued usage of Bigtable and Dataproc,
+delete your resources.
+
+    gsutil rm your-bucket-id
+    gcloud bigtable instances delete test-instance
+    gcloud dataproc clusters delete spark-cluster
+
+
+## Running tests
+
+Currently the tests use a local Spark instance but require a real Bigtable
+cluster to run again. Set the following environmet variables:
+
+     GOOGLE_CLOUD_PROJECT=your-project-id
+     CLOUD_BIGTABLE_INSTANCE=your-bigtable-instance
+
+Then run:
+
+    mvn test -DskipTests=false

--- a/scala/spark/wordcount/pom.xml
+++ b/scala/spark/wordcount/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <name>cloud-bigtable-hello-world</name>
+    <groupId>com.example.bigtable.helloworld</groupId>
+    <artifactId>cloud-bigtable-hello-world</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <bigtable.version>0.9.7.1</bigtable.version>
+        <hbase.version>1.1.5</hbase.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <scala.version>2.11.0</scala.version>
+    </properties>
+
+<dependencies>
+
+    <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-core_2.11</artifactId>
+        <version>2.1.1</version>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql_2.11 -->
+    <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-sql_2.11</artifactId>
+        <version>2.1.1</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.google.cloud.bigtable</groupId>
+        <artifactId>bigtable-hbase-1.1</artifactId>
+        <version>${bigtable.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-client</artifactId>
+        <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>1.1.33.Fork26</version>
+    </dependency>
+    <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.scalactic</groupId>
+        <artifactId>scalactic_2.11</artifactId>
+        <version>3.0.1</version>
+    </dependency>
+    <dependency>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest_2.11</artifactId>
+        <version>3.0.1</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+
+<build>
+<plugins>
+    <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>scala-compile-first</id>
+                <phase>process-resources</phase>
+                <goals>
+                    <goal>add-source</goal>
+                    <goal>compile</goal>
+                </goals>
+            </execution>
+            <execution>
+                <id>scala-test-compile</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                    <goal>testCompile</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
+
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+            <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+            </descriptorRefs>
+            <archive>
+                <manifest>
+                    <mainClass>WordCount</mainClass>
+                </manifest>
+            </archive>
+        </configuration>
+        <executions>
+            <execution>
+                <id>binary-assembly</id>
+                <goals>
+                    <goal>single</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
+</plugins>
+</build>
+</project>

--- a/scala/spark/wordcount/src/main/resources/countme.txt
+++ b/scala/spark/wordcount/src/main/resources/countme.txt
@@ -1,0 +1,35 @@
+The Cat only grinned when it saw Alice. It looked good-natured, she
+thought: still it had VERY long claws and a great many teeth, so she
+felt that it ought to be treated with respect.
+
+‘Cheshire Puss,’ she began, rather timidly, as she did not at all know
+whether it would like the name: however, it only grinned a little wider.
+‘Come, it’s pleased so far,’ thought Alice, and she went on. ‘Would you
+tell me, please, which way I ought to go from here?’
+
+‘That depends a good deal on where you want to get to,’ said the Cat.
+
+‘I don’t much care where--’ said Alice.
+
+‘Then it doesn’t matter which way you go,’ said the Cat.
+
+‘--so long as I get SOMEWHERE,’ Alice added as an explanation.
+
+‘Oh, you’re sure to do that,’ said the Cat, ‘if you only walk long
+enough.’
+
+Alice felt that this could not be denied, so she tried another question.
+‘What sort of people live about here?’
+
+‘In THAT direction,’ the Cat said, waving its right paw round, ‘lives
+a Hatter: and in THAT direction,’ waving the other paw, ‘lives a March
+Hare. Visit either you like: they’re both mad.’
+
+‘But I don’t want to go among mad people,’ Alice remarked.
+
+‘Oh, you can’t help that,’ said the Cat: ‘we’re all mad here. I’m mad.
+You’re mad.’
+
+‘How do you know I’m mad?’ said Alice.
+
+‘You must be,’ said the Cat, ‘or you wouldn’t have come here.’

--- a/scala/spark/wordcount/src/main/scala/WordCount.scala
+++ b/scala/spark/wordcount/src/main/scala/WordCount.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName}
+import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.spark._
+
+import scala.collection.JavaConversions._
+
+import com.google.cloud.bigtable.hbase.BigtableConfiguration
+
+/**
+  * Basic WordCount sample of using Cloud Dataproc (managed Apache Spark)
+  * to write to Cloud Bigtable.
+  */
+object WordCount {
+  val ColumnFamily = "cf"
+  val ColumnFamilyBytes = Bytes.toBytes(ColumnFamily)
+  val ColumnNameBytes = Bytes.toBytes("Count")
+
+  val WordCountTableName = "wordcount"
+
+  def createConnection(ProjectId: String, InstanceID: String): Connection = {
+    BigtableConfiguration.connect(ProjectId, InstanceID)
+  }
+
+  def writeWordCount(word: String, count: Integer, mutator:BufferedMutator) = {
+      mutator.mutate(new Put(Bytes.toBytes(word)).
+      addColumn(ColumnFamilyBytes,
+        ColumnNameBytes,
+        Bytes.toBytes(count)))
+  }
+
+  def createTableIfNotExists(connection: Connection) = {
+    val tableName = TableName.valueOf(WordCountTableName)
+    try {
+      val admin = connection.getAdmin()
+      if (!admin.tableExists(tableName)) {
+        val tableDescriptor = new HTableDescriptor(tableName)
+        tableDescriptor.addFamily(
+          new HColumnDescriptor(ColumnFamily))
+        admin.createTable(tableDescriptor)
+      }
+      admin.close()
+    }
+  }
+
+  def deleteTable(connection: Connection) = {
+    val tableName = TableName.valueOf(WordCountTableName)
+    try {
+      val admin = connection.getAdmin()
+      if (admin.tableExists(tableName)) {
+        admin.deleteTable(tableName)
+      }
+      admin.close()
+    }
+  }
+
+  def main(args: Array[String]) {
+    val ProjectId = args(0)
+    val InstanceID = args(1)
+    val WordCountTableName = args(2)
+    val File = args(3)
+
+    val sc = new SparkContext()
+
+    val createTableConnection = createConnection(ProjectId, InstanceID)
+    try {
+      createTableIfNotExists(createTableConnection)
+    } finally {
+      createTableConnection.close()
+    }
+
+    val wordCounts = sc.textFile(File).
+      flatMap(_.split(" ")).
+      filter(_!="").map((_,1)).
+      reduceByKey((a,b) => a+b)
+
+    wordCounts.foreachPartition {
+      partition => {
+        partition.foreach {
+          wordcount => {
+            val partitionConnection = createConnection(ProjectId, InstanceID)
+            val table = TableName.valueOf(WordCountTableName)
+            val mutator = partitionConnection.getBufferedMutator(table)
+            try {
+              partition.foreach {
+                wordCount => {
+                  val (word, count) = wordCount
+                  try {
+                    writeWordCount(word, count, mutator)
+                  } catch {
+                    case retries_e: RetriesExhaustedWithDetailsException => {
+                      retries_e.getCauses().foreach(_.printStackTrace)
+                      println("Retries: " + retries_e.getClass)
+                      throw retries_e.getCauses().get(0)
+                    }
+                  }
+                }
+              }
+            } finally {
+              mutator.close()
+              partitionConnection.close()
+            }
+          }
+        }
+      }
+    }
+
+    val deleteConnection = createConnection(ProjectId, InstanceID)
+    try {
+      deleteTable(deleteConnection)
+    } finally {
+      deleteConnection.close()
+    }
+
+  }
+}

--- a/scala/spark/wordcount/src/test/resources/countme.txt
+++ b/scala/spark/wordcount/src/test/resources/countme.txt
@@ -1,0 +1,35 @@
+The Cat only grinned when it saw Alice. It looked good-natured, she
+thought: still it had VERY long claws and a great many teeth, so she
+felt that it ought to be treated with respect.
+
+‘Cheshire Puss,’ she began, rather timidly, as she did not at all know
+whether it would like the name: however, it only grinned a little wider.
+‘Come, it’s pleased so far,’ thought Alice, and she went on. ‘Would you
+tell me, please, which way I ought to go from here?’
+
+‘That depends a good deal on where you want to get to,’ said the Cat.
+
+‘I don’t much care where--’ said Alice.
+
+‘Then it doesn’t matter which way you go,’ said the Cat.
+
+‘--so long as I get SOMEWHERE,’ Alice added as an explanation.
+
+‘Oh, you’re sure to do that,’ said the Cat, ‘if you only walk long
+enough.’
+
+Alice felt that this could not be denied, so she tried another question.
+‘What sort of people live about here?’
+
+‘In THAT direction,’ the Cat said, waving its right paw round, ‘lives
+a Hatter: and in THAT direction,’ waving the other paw, ‘lives a March
+Hare. Visit either you like: they’re both mad.’
+
+‘But I don’t want to go among mad people,’ Alice remarked.
+
+‘Oh, you can’t help that,’ said the Cat: ‘we’re all mad here. I’m mad.
+You’re mad.’
+
+‘How do you know I’m mad?’ said Alice.
+
+‘You must be,’ said the Cat, ‘or you wouldn’t have come here.’

--- a/scala/spark/wordcount/src/test/resources/hbase-site.xml
+++ b/scala/spark/wordcount/src/test/resources/hbase-site.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+    <property><name>google.bigtable.project.id</name><value>${bigtable.projectID}</value></property>
+    <property><name>google.bigtable.instance.id</name><value>${bigtable.instanceID}</value></property>
+    <property>
+        <name>hbase.client.connection.impl</name><value>com.google.cloud.bigtable.hbase1_2.BigtableConnection</value>
+    </property>
+</configuration>

--- a/scala/spark/wordcount/src/test/scala/HBaseSpec.scala
+++ b/scala/spark/wordcount/src/test/scala/HBaseSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+trait HBaseSpec  {
+/*  this: Suite =>
+
+  var _hbase : HBaseTestingUtility  = new HBaseTestingUtility()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    _hbase.startMiniCluster(1)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+  }
+  */
+
+}

--- a/scala/spark/wordcount/src/test/scala/SparkSpec.scala
+++ b/scala/spark/wordcount/src/test/scala/SparkSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
+
+trait SparkSpec extends BeforeAndAfterAll {
+  this: Suite =>
+
+  private var _sc: SparkContext = _
+  private var _spark: SparkSession = _
+
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val conf = new SparkConf()
+      .setMaster("local[*]")
+      .setAppName(this.getClass.getSimpleName)
+
+    sparkConfig.foreach { case (k, v) => conf.setIfMissing(k, v) }
+
+    _sc = new SparkContext(conf)
+
+    _spark = SparkSession.builder().
+      appName("Spark Bigtable Example").
+      getOrCreate()
+    sc.setLogLevel("WARN")
+  }
+
+  def sparkConfig: Map[String, String] = Map.empty
+
+  override def afterAll(): Unit = {
+    if (_sc != null) {
+      _sc.stop()
+      _sc = null
+    }
+    super.afterAll()
+  }
+
+  implicit def sc: SparkContext = _sc
+  implicit def spark: SparkSession = _spark
+
+
+}

--- a/scala/spark/wordcount/src/test/scala/WordCoundTest.scala
+++ b/scala/spark/wordcount/src/test/scala/WordCoundTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import java.nio.ByteBuffer
+
+import org.apache.hadoop.hbase.client.{ConnectionFactory, Get}
+import org.apache.hadoop.hbase.{HBaseConfiguration, TableName}
+import org.apache.hadoop.hbase.util.Bytes
+import org.scalatest.{FlatSpec, GivenWhenThen, Matchers}
+
+class WordCountTest extends FlatSpec with SparkSpec with Matchers {
+
+  "writeWordCount" should "write to hbase" in {
+    val tableName = TableName.valueOf("test2")
+    var hbaseConfig = HBaseConfiguration.create()
+    val TestWord = "test_word"
+    val Count = 3
+
+    val conn1 = ConnectionFactory.createConnection(hbaseConfig)
+    val table = conn1.getTable(tableName)
+    val mutator = conn1.getBufferedMutator(tableName)
+
+    WordCount.writeWordCount(TestWord, Count, mutator)
+    mutator.close()
+
+    val get = new Get(Bytes.toBytes(TestWord))
+    val result = table.get(get).getValue(WordCount.ColumnFamilyBytes, WordCount.ColumnNameBytes)
+    val intResult = Bytes.toInt(result)
+    intResult should equal(Count)
+  }
+}


### PR DESCRIPTION
This is an update of the Spark example previously in this repo. Now includes instructions for packaging and running on local Spark as well as on Cloud Dataproc.

Currently has a test that runs with local Spark and deployed Bigtable.  TODO is add full e2e test. 

sbt seems more popular in spark world but was having problems with it so using Maven for now, TODO to switch.