### PR TITLE
[DO NOT MEREGE] writeAsHadoopAPI attempt

### DIFF
--- a/spark/wordcount/README.md
+++ b/spark/wordcount/README.md
@@ -28,7 +28,7 @@ install Spark locally.
 
 If you don't already have a Cloud Bigtable instance, create one
 
-     gcloud bigtable instances create test-instance --cluster test-cluster --cluster-zone us-east1-b --cluster-num-nodes 3
+     gcloud beta bigtable instances create test-instance --cluster test-cluster --cluster-zone us-east1-b --cluster-num-nodes 3
 
 ## Create a Cloud Dataproc Cluster
 
@@ -76,7 +76,7 @@ Now submit your job to Cloud Dataproc:
 
     gcloud dataproc jobs submit spark --cluster spark-cluster \
     --class com.example.bigtable.spark.wordcount.WordCount  \
-    --jar target/cloud-bigtable-hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar \
+    --jars target/cloud-bigtable-hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar \
     -- your-project-id your-bigtable-instance-id wordcountproc gs://your-bucket-id/countme.txt
 
 ## Clean up resources
@@ -85,7 +85,7 @@ If you don't want to be charged for continued usage of Bigtable and Dataproc,
 delete your resources.
 
     gsutil rm your-bucket-id
-    gcloud bigtable instances delete test-instance
+    gcloud beta bigtable instances delete test-instance
     gcloud dataproc clusters delete spark-cluster
 
 

--- a/spark/wordcount/README.md
+++ b/spark/wordcount/README.md
@@ -1,0 +1,102 @@
+# Dataproc Bigtable WordCount Sample
+
+## Overview
+
+This sample demonstrates how to use  [Google Cloud Dataproc](http://cloud.google.com/dataproc), which
+provides a managed [Apache Spark](https://spark.apache.org/) environment with
+[Google Cloud Bigtable](http://cloud.google.com/bigtable/docs).
+
+This specific example provides the classic map reduce example of counting words
+in a text file.
+
+## Prerequisites
+
+1. A [Google Cloud project](console.cloud.google.com) with billing enabled. Please
+be aware of [Bigtable](https://cloud.google.com/bigtable/pricing)
+and [Dataproc](https://cloud.google.com/dataproc/docs/resources/pricing) pricing.
+
+1. You have the [Google Cloud SDK](https://cloud.google.com/sdk/) installed.
+
+1. You have [Scala](https://www.scala-lang.org/) installed.
+
+1. You have basic familiarity with Spark and Scala. It may be helpful to
+install Spark locally.
+
+1. You have [Maven](https://maven.apache.org/) installed.
+
+## Create a Cloud Bigtable Instance
+
+If you don't already have a Cloud Bigtable instance, create one
+
+     gcloud bigtable instances create test-instance --cluster test-cluster --cluster-zone us-east1-b --cluster-num-nodes 3
+
+## Create a Cloud Dataproc Cluster
+
+Create a Cloud DataProc instance:
+
+    gcloud dataproc clusters create spark-cluster
+
+## Build the jar
+
+The Spark job is assembled into a fat jar with all its dependencies. To build, run
+
+   mvn assembly:assembly
+
+## Test your job locally (optional but recommended)
+
+This step requires a local Spark installation.
+
+While you will need a real Bigtable cluster, you can test the Spark job locally,
+if you have Spark insatlled. For testing, consider a Bigtable development
+cluster.
+
+    spark-submit --master local --class com.example.bigtable.spark.wordcount.WordCount \
+    target/cloud-bigtable-dataproc-spark-wordcount-0.1-jar-with-dependencies.jar \
+     your-project-id your-bigtable-instance-id wordcount-scratch \
+     src/test/resources/countme.txt
+
+The job will create the table specified (here, `wordcount`) if it doesn't already exist.
+
+## Submit your job to Dataproc
+
+### Create a Google Cloud Storage bucket
+
+For deployed jobs on Cloud Dataproc, it's easiest to read a file from Google
+Cloud Storage. You can use `gsutil` to create the bucket.
+
+    gsutil mb gs://your-unique-bucket-id
+
+Once done, upload the sample file (or a file of your choice) to the bucket:
+
+    gsutil cp src/test/resources/countme.txt gs://your-unique-bucket-id
+
+### Submit the job to Cloud Dataproc
+
+Now submit your job to Cloud Dataproc:
+
+    gcloud dataproc jobs submit spark --cluster spark-cluster \
+    --class com.example.bigtable.spark.wordcount.WordCount  \
+    --jar target/cloud-bigtable-hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar \
+    -- your-project-id your-bigtable-instance-id wordcountproc gs://your-bucket-id/countme.txt
+
+## Clean up resources
+
+If you don't want to be charged for continued usage of Bigtable and Dataproc,
+delete your resources.
+
+    gsutil rm your-bucket-id
+    gcloud bigtable instances delete test-instance
+    gcloud dataproc clusters delete spark-cluster
+
+
+## Running tests
+
+Currently the tests use a local Spark instance but require a real Bigtable
+cluster to run again. Set the following environmet variables:
+
+     GOOGLE_CLOUD_PROJECT=your-project-id
+     CLOUD_BIGTABLE_INSTANCE=your-bigtable-instance
+
+Then run:
+
+    mvn test -DskipTests=false

--- a/spark/wordcount/README.md
+++ b/spark/wordcount/README.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-This sample demonstrates how to use  [Google Cloud Dataproc](http://cloud.google.com/dataproc), which
+This sample demonstrates how to use  [Google Cloud Dataproc](https://cloud.google.com/dataproc), which
 provides a managed [Apache Spark](https://spark.apache.org/) environment with
-[Google Cloud Bigtable](http://cloud.google.com/bigtable/docs).
+[Google Cloud Bigtable](https://cloud.google.com/bigtable/docs).
 
 This specific example provides the classic map reduce example of counting words
 in a text file.
 
 ## Prerequisites
 
-1. A [Google Cloud project](console.cloud.google.com) with billing enabled. Please
+1. A [Google Cloud project](https://console.cloud.google.com/) with billing enabled. Please
 be aware of [Bigtable](https://cloud.google.com/bigtable/pricing)
 and [Dataproc](https://cloud.google.com/dataproc/docs/resources/pricing) pricing.
 
@@ -40,7 +40,7 @@ Create a Cloud DataProc instance:
 
 The Spark job is assembled into a fat jar with all its dependencies. To build, run
 
-   mvn assembly:assembly
+    mvn assembly:assembly
 
 ## Test your job locally (optional but recommended)
 
@@ -52,8 +52,8 @@ cluster.
 
     spark-submit --master local --class com.example.bigtable.spark.wordcount.WordCount \
     target/cloud-bigtable-dataproc-spark-wordcount-0.1-jar-with-dependencies.jar \
-     your-project-id your-bigtable-instance-id wordcount-scratch \
-     src/test/resources/countme.txt
+    your-project-id your-bigtable-instance-id wordcount-scratch \
+    src/test/resources/countme.txt
 
 The job will create the table specified (here, `wordcount`) if it doesn't already exist.
 
@@ -62,7 +62,7 @@ The job will create the table specified (here, `wordcount`) if it doesn't alread
 ### Create a Google Cloud Storage bucket
 
 For deployed jobs on Cloud Dataproc, it's easiest to read a file from Google
-Cloud Storage. You can use `gsutil` to create the bucket.
+Cloud Storage. You can use `gsutil` to create the bucket:
 
     gsutil mb gs://your-unique-bucket-id
 

--- a/spark/wordcount/pom.xml
+++ b/spark/wordcount/pom.xml
@@ -77,11 +77,11 @@
             <artifactId>hbase-client</artifactId>
             <version>${hbase.version}</version>
         </dependency>
-        <!--<dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <version>1.1.33.Fork26</version>
-        </dependency>-->
+        </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>

--- a/spark/wordcount/pom.xml
+++ b/spark/wordcount/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>cloud-bigtable-dataproc-spark-wordcount</name>
+    <groupId>com.example.bigtable.spark.wordcount</groupId>
+    <artifactId>cloud-bigtable-dataproc-spark-wordcount</artifactId>
+    <packaging>jar</packaging>
+    <version>0.1</version>
+
+    <properties>
+        <bigtable.version>0.9.7.1</bigtable.version>
+        <hbase.version>1.3.1</hbase.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <spark.version>2.1.1</spark.version>
+        <scala.version>2.11.0</scala.version>
+        <scalatest.version>3.0.3</scalatest.version>
+        <skipTests>true</skipTests>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.11</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.11</artifactId>
+            <version>${spark.version}</version>
+            <!---<scope>provided</scope>-->
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.bigtable</groupId>
+            <artifactId>bigtable-hbase-1.1</artifactId>
+            <version>${bigtable.version}</version>
+        </dependency>
+
+        <!-- hadoop-client and hadoop-common are not used directly. They are
+        included here to workaround an issue with mismatched versions of Guava
+        being needed by hbase-client and spark -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>2.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>2.7.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>1.1.33.Fork26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalactic</groupId>
+            <artifactId>scalactic_2.11</artifactId>
+            <version>${scalatest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.11</artifactId>
+            <version>${scalatest.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>WordCount</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>binary-assembly</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0</version>
+                <configuration>
+                    <skipTests>${skipTests}</skipTests>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scala-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spark/wordcount/pom.xml
+++ b/spark/wordcount/pom.xml
@@ -9,13 +9,14 @@
     <version>0.1</version>
 
     <properties>
-        <bigtable.version>0.9.7.1</bigtable.version>
+        <bigtable.version>1.0.0-pre2</bigtable.version>
         <hbase.version>1.3.1</hbase.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <spark.version>2.1.1</spark.version>
         <scala.version>2.11.0</scala.version>
         <scalatest.version>3.0.3</scalatest.version>
+        <hadoop.version>2.7.2</hadoop.version>
         <skipTests>true</skipTests>
     </properties>
 
@@ -24,43 +25,63 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
             <version>${spark.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.11</artifactId>
             <version>${spark.version}</version>
-            <!---<scope>provided</scope>-->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigtable</groupId>
-            <artifactId>bigtable-hbase-1.1</artifactId>
-            <version>${bigtable.version}</version>
+            <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
+            <version>1.0.0-pre2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>1.3.1</version>
         </dependency>
 
         <!-- hadoop-client and hadoop-common are not used directly. They are
         included here to workaround an issue with mismatched versions of Guava
         being needed by hbase-client and spark -->
+        <!--
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>2.7.2</version>
+            <version>${hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.2</version>
+            <version>${hadoop.version}</version>
         </dependency>
+        -->
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
             <version>${hbase.version}</version>
         </dependency>
-        <dependency>
+        <!--<dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <version>1.1.33.Fork26</version>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>

--- a/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
+++ b/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
@@ -1,15 +1,11 @@
 /*
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *            http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
+++ b/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
@@ -99,6 +99,11 @@ object WordCount {
       flatMap(_.split(" ")).
       filter(_ != "").map((_, 1)).
       reduceByKey((a, b) => a + b)
+      .map({
+        case (word, count) =>
+          (null, new Put(Bytes.toBytes(word))
+            .addColumn(ColumnFamilyBytes, ColumnNameBytes, Bytes.toBytes(count)))
+      })
 
     // Create a per-partition connection to ensure each node has a
     // connection (partitions are on at most 1 node).

--- a/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
+++ b/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
@@ -60,6 +60,14 @@ object WordCount {
     }
   }
 
+  def writeWordCount(word: String, count: Integer, mutator: BufferedMutator) = {
+       mutator.mutate(new Put(Bytes.toBytes(word)).
+         addColumn(ColumnFamilyBytes,
+              ColumnNameBytes,
+              Bytes.toBytes(count)))
+      }
+
+
   /**
     * Main entry point for running the WordCount spark job and writing
     * the results to Bigtable.
@@ -84,7 +92,7 @@ object WordCount {
     }
 
     var conf = BigtableConfiguration.configure(
-      "waprin-spark", "test-bigtable2")
+      "waprin-spark", "test-bigtable")
     conf.set(TableInputFormat.INPUT_TABLE, outputTableName)
     conf.set(TableOutputFormat.OUTPUT_TABLE, outputTableName)
     conf.setInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT, 60000)
@@ -104,10 +112,15 @@ object WordCount {
           (null, new Put(Bytes.toBytes(word))
             .addColumn(ColumnFamilyBytes, ColumnNameBytes, Bytes.toBytes(count)))
       })
+    /*
+    val wordCounts = sc.textFile(fileName).
+      flatMap(_.split(" ")).
+      filter(_ != "").map((_, 1)).
+      reduceByKey((a, b) => a + b)
 
     // Create a per-partition connection to ensure each node has a
     // connection (partitions are on at most 1 node).
-    /*wordCounts.foreachPartition {
+    wordCounts.foreachPartition {
       partition => {
         val partitionConnection = createConnection(projectId, instanceId)
         val table = TableName.valueOf(tableName)
@@ -115,9 +128,9 @@ object WordCount {
         try {
           partition.foreach {
             wordCount => {
-              val (word, count) = wordCount
+              val (word, count2) = wordCount
               try {
-                writeWordCount(word, count, mutator)
+                writeWordCount(word, count2, mutator)
               } catch {
                 case retries_e: RetriesExhaustedWithDetailsException => {
                   println("Retries: " + retries_e.getClass)

--- a/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
+++ b/spark/wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigtable.spark.wordcount
+
+import com.google.cloud.bigtable.hbase.BigtableConfiguration
+import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName}
+import org.apache.hadoop.hbase.client.{BufferedMutator, Connection, Put, RetriesExhaustedWithDetailsException}
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.spark.SparkContext
+
+/**
+  * Basic WordCount sample of using Cloud Dataproc (managed Apache Spark)
+  * to write to Cloud Bigtable.
+  */
+object WordCount {
+  val ColumnFamily = "cf"
+  val ColumnFamilyBytes = Bytes.toBytes(ColumnFamily)
+  val ColumnNameBytes = Bytes.toBytes("Count")
+
+  def createConnection(ProjectId: String, InstanceID: String): Connection = {
+    BigtableConfiguration.connect(ProjectId, InstanceID)
+  }
+
+  /**
+    * Write the count of the word to Cloud Bigtable using the word itself
+    * as the row key.
+    *
+    * @param word    The word we are writing the count of, and row key
+    * @param count   The frequency of the word in the document
+    * @param mutator A Cloud Bigtable mutator for writing
+    */
+  def writeWordCount(word: String, count: Integer, mutator: BufferedMutator) = {
+    mutator.mutate(new Put(Bytes.toBytes(word)).
+      addColumn(ColumnFamilyBytes,
+        ColumnNameBytes,
+        Bytes.toBytes(count)))
+  }
+
+  /**
+    * Create a table in the Cloud Bigtable instance if it doesn't already
+    * exit.
+    *
+    * @param connection A Cloud Bigtable connection
+    * @param name       The table name
+    */
+  def createTableIfNotExists(connection: Connection, name: String) = {
+    val tableName = TableName.valueOf(name)
+    val admin = connection.getAdmin()
+    try {
+      if (!admin.tableExists(tableName)) {
+        val tableDescriptor = new HTableDescriptor(tableName)
+        tableDescriptor.addFamily(
+          new HColumnDescriptor(ColumnFamily))
+        admin.createTable(tableDescriptor)
+      }
+    } finally {
+      admin.close()
+    }
+  }
+
+  /**
+    * Main entry point for running the WordCount spark job and writing
+    * the results to Bigtable.
+    *
+    * @param projectId  The Google Cloud Project ID
+    * @param instanceId The Cloud Bigtable instance name
+    * @param tableName  The name of the Cloud Bigtable table to write to
+    * @param fileName   The file (local or gcs) to sort
+    * @param sc         The Spark context
+    */
+  def runner(projectId: String, instanceId: String,
+             tableName: String, fileName: String,
+             sc: SparkContext) = {
+    val createTableConnection = createConnection(projectId, instanceId)
+    try {
+      createTableIfNotExists(createTableConnection, tableName)
+    } finally {
+      createTableConnection.close()
+    }
+
+    val wordCounts = sc.textFile(fileName).
+      flatMap(_.split(" ")).
+      filter(_ != "").map((_, 1)).
+      reduceByKey((a, b) => a + b)
+
+    // Create a per-partition connection to ensure each node has a
+    // connection (partitions are on at most 1 node).
+    wordCounts.foreachPartition {
+      partition => {
+        val partitionConnection = createConnection(projectId, instanceId)
+        val table = TableName.valueOf(tableName)
+        val mutator = partitionConnection.getBufferedMutator(table)
+        try {
+          partition.foreach {
+            wordCount => {
+              val (word, count) = wordCount
+              try {
+                writeWordCount(word, count, mutator)
+              } catch {
+                case retries_e: RetriesExhaustedWithDetailsException => {
+                  println("Retries: " + retries_e.getClass)
+                  throw retries_e.getCauses().get(0)
+                }
+              }
+            }
+          }
+        } finally {
+          mutator.close()
+          partitionConnection.close()
+        }
+      }
+    }
+  }
+
+  /**
+    * Main program parses command line args and creates Spark context.
+    * @param args
+    */
+  def main(args: Array[String]) {
+    val ProjectId = args(0)
+    val InstanceID = args(1)
+    val WordCountTableName = args(2)
+    val File = args(3)
+    val sc = new SparkContext()
+    runner(ProjectId, InstanceID, WordCountTableName, File, sc)
+  }
+}

--- a/spark/wordcount/src/test/resources/countme.txt
+++ b/spark/wordcount/src/test/resources/countme.txt
@@ -1,0 +1,35 @@
+The Cat only grinned when it saw Alice. It looked good-natured, she
+thought: still it had VERY long claws and a great many teeth, so she
+felt that it ought to be treated with respect.
+
+‘Cheshire Puss,’ she began, rather timidly, as she did not at all know
+whether it would like the name: however, it only grinned a little wider.
+‘Come, it’s pleased so far,’ thought Alice, and she went on. ‘Would you
+tell me, please, which way I ought to go from here?’
+
+‘That depends a good deal on where you want to get to,’ said the Cat.
+
+‘I don’t much care where--’ said Alice.
+
+‘Then it doesn’t matter which way you go,’ said the Cat.
+
+‘--so long as I get SOMEWHERE,’ Alice added as an explanation.
+
+‘Oh, you’re sure to do that,’ said the Cat, ‘if you only walk long
+enough.’
+
+Alice felt that this could not be denied, so she tried another question.
+‘What sort of people live about here?’
+
+‘In THAT direction,’ the Cat said, waving its right paw round, ‘lives
+a Hatter: and in THAT direction,’ waving the other paw, ‘lives a March
+Hare. Visit either you like: they’re both mad.’
+
+‘But I don’t want to go among mad people,’ Alice remarked.
+
+‘Oh, you can’t help that,’ said the Cat: ‘we’re all mad here. I’m mad.
+You’re mad.’
+
+‘How do you know I’m mad?’ said Alice.
+
+‘You must be,’ said the Cat, ‘or you wouldn’t have come here.’

--- a/spark/wordcount/src/test/scala/com/example/bigtable/spark/wordcount/SparkSpec.scala
+++ b/spark/wordcount/src/test/scala/com/example/bigtable/spark/wordcount/SparkSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigtable.spark.wordcount
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
+
+
+trait SparkSpec extends BeforeAndAfterAll {
+  this: Suite =>
+
+  private var _sc: SparkContext = _
+  private var _spark: SparkSession = _
+
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val conf = new SparkConf()
+      .setMaster("local[*]")
+      .setAppName(this.getClass.getSimpleName)
+
+    sparkConfig.foreach { case (k, v) => conf.setIfMissing(k, v) }
+
+    _sc = new SparkContext(conf)
+
+    _spark = SparkSession.builder().
+      appName("Spark Bigtable Example").
+      getOrCreate()
+    sc.setLogLevel("WARN")
+  }
+
+  def sparkConfig: Map[String, String] = Map.empty
+
+  override def afterAll(): Unit = {
+    if (_sc != null) {
+      _sc.stop()
+      _sc = null
+    }
+    super.afterAll()
+  }
+
+  implicit def sc: SparkContext = _sc
+  implicit def spark: SparkSession = _spark
+
+
+}

--- a/spark/wordcount/src/test/scala/com/example/bigtable/spark/wordcount/WordCountIT.scala
+++ b/spark/wordcount/src/test/scala/com/example/bigtable/spark/wordcount/WordCountIT.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigtable.spark.wordcount
+
+import com.example.bigtable.spark.wordcount.WordCount.ColumnFamily
+import org.apache.hadoop.hbase.client.{Get, Scan}
+import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName}
+import org.apache.hadoop.hbase.util.Bytes
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+
+/**
+  * Word count integration test. While the Spark cluster is spun up locally
+  * and programmatically, this test requires a live Cloud Bigtable cluster to
+  * exist.
+  */
+class WordCountIT extends FlatSpec with BeforeAndAfterEach with BeforeAndAfterAll with SparkSpec with Matchers {
+
+  val ProjectId = sys.env("GOOGLE_CLOUD_PROJECT")
+  val BigTableInstance = sys.env("CLOUD_BIGTABLE_INSTANCE")
+  val WordCountTableName= "WordCount-Test-Scratch-Table"
+
+  def fixture =
+    new {
+      val connection = WordCount.createConnection(ProjectId, BigTableInstance)
+      val tableName = TableName.valueOf(WordCountTableName)
+    }
+
+  /**
+    * Deletes test table after each test.
+    */
+  private def deleteScratchTable() {
+    val f = fixture
+    val tableName = TableName.valueOf(WordCountTableName)
+    val admin = f.connection.getAdmin()
+    try {
+      admin.deleteTable(tableName)
+    } finally {
+      admin.close()
+    }
+  }
+
+  /**
+    * Helper to read word count from table.
+    * @return
+    */
+  private def getWordCount(word: String): Integer = {
+    val f = fixture
+    val get = new Get(Bytes.toBytes(word))
+    val table = f.connection.getTable(f.tableName)
+    val result = table.get(get).getValue(WordCount.ColumnFamilyBytes, WordCount.ColumnNameBytes)
+    Bytes.toInt(result)
+  }
+
+
+  /**
+    * Deletes scratch table after each test.
+    */
+  override def afterEach() {
+    deleteScratchTable()
+  }
+
+  override def afterAll(): Unit = {
+    fixture.connection.close()
+  }
+
+  "writeWordCount" should "write to Bigtable" in {
+    val TestWord = "test_word"
+    val Count = 3
+
+    val f = fixture
+
+    val mutator = f.connection.getBufferedMutator(f.tableName)
+
+    WordCount.createTableIfNotExists(f.connection, WordCountTableName)
+    WordCount.writeWordCount(TestWord, Count, mutator)
+    mutator.close()
+
+    val count = getWordCount(TestWord)
+    count should equal(Count)
+  }
+
+  "main runner" should "count words in sample file" in {
+    val f = fixture
+    val path = getClass.getResource("/countme.txt").getPath
+
+    WordCount.runner(ProjectId, BigTableInstance, WordCountTableName, path, this.sc)
+
+    val table = f.connection.getTable(f.tableName)
+    val scanner = table.getScanner(new Scan())
+
+    var count = 0
+    var rs = scanner.next
+    while ( {
+      rs != null
+    }) {
+      count += 1
+      rs = scanner.next
+    }
+    count should equal(162)
+  }
+}

--- a/spark/wordcount/src/test/scala/com/example/bigtable/spark/wordcount/WordCountIT.scala
+++ b/spark/wordcount/src/test/scala/com/example/bigtable/spark/wordcount/WordCountIT.scala
@@ -76,7 +76,7 @@ class WordCountIT extends FlatSpec with BeforeAndAfterEach with BeforeAndAfterAl
   override def afterAll(): Unit = {
     fixture.connection.close()
   }
-
+                   /*
   "writeWordCount" should "write to Bigtable" in {
     val TestWord = "test_word"
     val Count = 3
@@ -91,13 +91,17 @@ class WordCountIT extends FlatSpec with BeforeAndAfterEach with BeforeAndAfterAl
 
     val count = getWordCount(TestWord)
     count should equal(Count)
-  }
+  }                  */
 
   "main runner" should "count words in sample file" in {
     val f = fixture
     val path = getClass.getResource("/countme.txt").getPath
+    val OutputTableName = "wordcount-output"
 
-    WordCount.runner(ProjectId, BigTableInstance, WordCountTableName, path, this.sc)
+    WordCount.runner(ProjectId, BigTableInstance,
+      WordCountTableName,
+      OutputTableName,
+      path, this.sc)
 
     val table = f.connection.getTable(f.tableName)
     val scanner = table.getScanner(new Scan())


### PR DESCRIPTION
This is branch that tries to switch #240 to use ` wordCounts.saveAsNewAPIHadoopDataset(conf)`.

Running: 

     mvn clean assembly:assembly -DskipTests=false

Leads to:

```
  org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 1.0 failed 1 times, most recent failure: Lost task 0.0 in stage 1.0 (TID 2, localhost, executor driver): java.lang.ClassCastException: java.lang.Integer cannot be cast to org.apache.hadoop.hbase.client.Mutation
```

cc @sduskis @pmkc
