### PR TITLE
Update java hello README to include required step

### DIFF
--- a/java/hello-world/README.md
+++ b/java/hello-world/README.md
@@ -116,7 +116,7 @@ SDK][cloud-sdk-init] with the command:
 
 		gcloud init
 
-Or with the [application-default login](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) command:
+Generate a credentials file by running the [application-default login](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) command:
 
     gcloud auth application-default login
 


### PR DESCRIPTION
The README makes it sound like `gcloud auth application-default login` can be replaced by gcloud login, however
generating a `application_default_credentials.json` will still be needed. This change will handle that bit of setup for the user.