### PR TITLE
Replace "cluster" with "instance" [skip ci]

### DIFF
--- a/java/hello-world/README.md
+++ b/java/hello-world/README.md
@@ -157,16 +157,12 @@ from the underlying libraries:
 To avoid incurring extra charges to your Google Cloud Platform account, remove
 the resources created for this sample.
 
-1.  Go to the Clusters page in the [Cloud
-    Console](https://console.cloud.google.com).
+1.  Go to the [Cloud Bigtable instance page](https://console.cloud.google.com/project/_/bigtable/instances) in the Cloud Console.
 
-    [Go to the Clusters page](https://console.cloud.google.com/project/_/bigtable/clusters)
+1.  Click on the instance name.
 
-1.  Click the cluster name.
+1.  Click **Delete instance**.
 
-1.  Click **Delete**.
+    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-instance.png)
 
-    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-cluster.png)
-
-1. Type the cluster ID, then click **Delete** to delete the cluster.
-
+1. Type the instance ID, then click **Delete** to delete the instance.

--- a/java/tracing-hello-world/README.md
+++ b/java/tracing-hello-world/README.md
@@ -251,16 +251,12 @@ that sets up tracing
 To avoid incurring extra charges to your Google Cloud Platform account, remove
 the resources created for this sample.
 
-1.  Go to the Clusters page in the [Cloud
-    Console](https://console.cloud.google.com).
+1.  Go to the [Cloud Bigtable instance page](https://console.cloud.google.com/project/_/bigtable/instances) in the Cloud Console.
 
-    [Go to the Clusters page](https://console.cloud.google.com/project/_/bigtable/clusters)
+1.  Click on the instance name.
 
-1.  Click the cluster name.
+1.  Click **Delete instance**.
 
-1.  Click **Delete**.
+    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-instance.png)
 
-    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-cluster.png)
-
-1. Type the cluster ID, then click **Delete** to delete the cluster.
-
+1. Type the instance ID, then click **Delete** to delete the instance.

--- a/node/cloud-functions/README.md
+++ b/node/cloud-functions/README.md
@@ -168,15 +168,12 @@ You should see something like this:
 To avoid incurring extra charges to your Google Cloud Platform account, remove
 the resources created for this sample.
 
-1.  Go to the Clusters page in the [Cloud
-    Console](https://console.cloud.google.com).
+1.  Go to the [Cloud Bigtable instance page](https://console.cloud.google.com/project/_/bigtable/instances) in the Cloud Console.
 
-    [Go to the Clusters page](https://console.cloud.google.com/project/_/bigtable/clusters)
+1.  Click on the instance name.
 
-1.  Click the cluster name.
+1.  Click **Delete instance**.
 
-1.  Click **Delete**.
+    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-instance.png)
 
-    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-cluster.png)
-
-1. Type the cluster ID, then click **Delete** to delete the cluster.
+1. Type the instance ID, then click **Delete** to delete the instance.

--- a/node/hello-world/README.md
+++ b/node/hello-world/README.md
@@ -159,16 +159,12 @@ from the underlying libraries:
 To avoid incurring extra charges to your Google Cloud Platform account, remove
 the resources created for this sample.
 
-1.  Go to the Clusters page in the [Cloud
-    Console](https://console.cloud.google.com).
+1.  Go to the [Cloud Bigtable instance page](https://console.cloud.google.com/project/_/bigtable/instances) in the Cloud Console.
 
-    [Go to the Clusters page](https://console.cloud.google.com/project/_/bigtable/clusters)
+1.  Click on the instance name.
 
-1.  Click the cluster name.
+1.  Click **Delete instance**.
 
-1.  Click **Delete**.
+    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-instance.png)
 
-    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-cluster.png)
-
-1. Type the cluster ID, then click **Delete** to delete the cluster.
-
+1. Type the instance ID, then click **Delete** to delete the instance.


### PR DESCRIPTION
Update instructions to delete resources provisioned for examples to refer to
instances instead of clusters, including URLs to the Cloud Console and
screenshots of the confirmation dialog.

Fixes #274.