### PR TITLE
Updating hello world to 1.5.0

### DIFF
--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -32,7 +32,7 @@
   </parent>
 
   <properties>
-    <bigtable.version>1.0.0</bigtable.version>
+    <bigtable.version>1.5.0</bigtable.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
@@ -67,3 +67,4 @@
     </plugins>
   </build>
 </project>
+

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,11 +26,13 @@ limitations under the License.
     The parent pom defines common style checks and testing strategies for code samples.
     Removing or replacing it should not affect the execution of the samples in anyway.
   -->
+  <!-- sduskis: this breaks the build
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
     <version>1.0.10</version>
   </parent>
+  -->
 
   <modules>
     <module>dataflow-coinbase</module>
@@ -48,3 +50,4 @@ limitations under the License.
     <module>connect</module>
   </modules>
 </project>
+

--- a/java/tracing-hello-world/pom.xml
+++ b/java/tracing-hello-world/pom.xml
@@ -32,11 +32,31 @@
   </parent>
 
   <properties>
-    <bigtable.version>1.3.0</bigtable.version>
-    <opencensus.version>0.12.2</opencensus.version>
+    <bigtable.version>1.5.0</bigtable.version>
+    <google-cloud.version>0.54.0-alpha</google-cloud.version>
+    <opencensus.version>0.12.3</opencensus.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-clients</artifactId>
+        <version>${google-cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bom</artifactId>
+        <version>${google-cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <repositories>
     <repository>
@@ -76,6 +96,10 @@
       <version>${opencensus.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>io.grpc</groupId>
           <artifactId>*</artifactId>
         </exclusion>
@@ -100,6 +124,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-auth</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
       <version>${opencensus.version}</version>
@@ -113,6 +142,11 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-trace</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I'm turning off shared-configuration.  I always get "Failed during checkstyle configuration: SuppressionCommentFilter is not allowed as a child in Checker" which is something that I don't know how to fix.  It something wrong in shared-configuration. 