### PR TITLE
Add connection refresh example

### DIFF
--- a/go/connection-refresh/README.md
+++ b/go/connection-refresh/README.md
@@ -1,0 +1,14 @@
+# Connection Refresh Example
+This is a simple example of how a Cloud Bigtable connection
+could be managed to mitigate the periodic connection refreshes
+that occur in normal operation. The principle is to start up
+a new connection in the background at some interval and run some
+RPCs on it before swapping it into the serving path.
+
+Note that this works best for short reads. A single scan will use
+just one connection. The lameduck time should be larger than any single
+RPC you perform, and the refresh interval should be low enough that an
+existing connection should not be close enough to the maximum life + duration
+of an RPC (or the serving connection will hit the cutoff and be reset).
+
+The maximum life is here considered to be about an hour.

--- a/go/connection-refresh/btrefresh/bigtable_rotator.go
+++ b/go/connection-refresh/btrefresh/bigtable_rotator.go
@@ -1,0 +1,93 @@
+package btrefresh
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+)
+
+// Time to wait before killing the previous connection
+// during rotation. This may kill ongoing requests if they
+// take longer than this amount of time.
+const lameduckTime = 1 * time.Minute
+
+// RotatingTable is a bigtable.Table that automatically
+// reconnects to Cloud Bigtable at a given interval.
+type RotatingTable struct {
+	*bigtable.Table
+	client *bigtable.Client
+	swap   *time.Ticker
+	errors chan error
+}
+
+// BackgroundErrors is a channel that will propagate errors
+// that come from refreshing the connection. It can either be
+// checked with select before performing ops or watched
+// in a background thread.
+func (r RotatingTable) BackgroundErrors() <-chan error {
+	return r.errors
+}
+
+// Close will close the connections and stop rotating.
+func (r RotatingTable) Close() {
+	r.swap.Stop()
+	close(r.errors)
+	r.client.Close()
+}
+
+// BtDialer encapsulates making a connection to your bigtable.
+// This way you can use any means for dialing/ getting credentials.
+type BtDialer func() (*bigtable.Client, error)
+
+// NewRotatingTable makes a new Table reference that will refresh itself in the background at the given
+// interval.
+func NewRotatingTable(dialer BtDialer, table string, refresh time.Duration) (*RotatingTable, error) {
+	client, err := dialer()
+	errors := make(chan error, 1)
+	if err != nil {
+		return nil, err
+	}
+	tbl := client.Open(table)
+	warmTable(tbl)
+	ticker := time.NewTicker(refresh)
+	rt := &RotatingTable{tbl, client, ticker, errors}
+	go func() {
+		for _ = range ticker.C {
+			// Close the old client after waiting a bit
+			go func() {
+				oldC := rt.client
+				time.Sleep(lameduckTime)
+				oldC.Close()
+			}()
+			client, err := dialer()
+			if err != nil {
+				errors <- err
+				continue
+			}
+			tbl := client.Open(table)
+			warmTable(tbl)
+			rt.Table = tbl
+		}
+	}()
+	return rt, nil
+}
+
+// A new table reference will need to have some requests
+// go across it to establish each connection in the connection
+// pool.
+func warmTable(tbl *bigtable.Table) {
+	wg := sync.WaitGroup{}
+	// Run the warming requests across threads to saturate the
+	// connection pool.
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			// Send a request that does not actually return data.
+			tbl.ReadRow(context.Background(), "NOT_A_REAL_ROW")
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/go/connection-refresh/btrefresh/bigtable_rotator.go
+++ b/go/connection-refresh/btrefresh/bigtable_rotator.go
@@ -13,6 +13,12 @@ import (
 // take longer than this amount of time.
 const lameduckTime = 1 * time.Minute
 
+// Number of requests to issue on a new client
+// to warm up each underlying client in the pool.
+// The default pool size is 4, so we run 2n to have
+// good chances of hitting them all.
+const nWarmConnections = 2 * 4
+
 // RotatingTable is a bigtable.Table that automatically
 // reconnects to Cloud Bigtable at a given interval.
 type RotatingTable struct {
@@ -81,7 +87,7 @@ func warmTable(tbl *bigtable.Table) {
 	wg := sync.WaitGroup{}
 	// Run the warming requests across threads to saturate the
 	// connection pool.
-	for i := 0; i < 32; i++ {
+	for i := 0; i < nWarmConnections; i++ {
 		wg.Add(1)
 		go func() {
 			// Send a request that does not actually return data.

--- a/go/connection-refresh/btrefresh/bigtable_rotator.go
+++ b/go/connection-refresh/btrefresh/bigtable_rotator.go
@@ -60,7 +60,7 @@ func NewRotatingTable(dialer BtDialer, table string, refresh time.Duration) (*Ro
 	ticker := time.NewTicker(refresh)
 	rt := &RotatingTable{tbl, client, ticker, errors}
 	go func() {
-		for _ = range ticker.C {
+		for range ticker.C {
 			// Close the old client after waiting a bit
 			go func() {
 				oldC := rt.client

--- a/go/connection-refresh/example_program.go
+++ b/go/connection-refresh/example_program.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"time"
+
+	"./btrefresh"
+	"cloud.google.com/go/bigtable"
+)
+
+var project = flag.String("project", "", "google cloud project")
+var instance = flag.String("bt_instance", "", "cloud bigtable instance")
+var table = flag.String("bt_table", "", "cloud bigtable table")
+
+// A row key to read in your table - held constant
+// to show the difference in performance with the connection
+// instead of bigtable performance.
+const rowKey = "0000010000"
+
+// tableRefreshTime is the amount of time between refreshing the connection
+// to cloud bigtable.
+const tableRefreshTime = 45 * time.Minute
+
+func main() {
+	flag.Parse()
+
+	// Create a new bigtable.Table that will refresh the connection periodically.
+	table, err := btrefresh.NewRotatingTable(func() (*bigtable.Client, error) {
+		return bigtable.NewClient(context.Background(), *project, *instance)
+	}, *table, tableRefreshTime)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Watch for background errors from the rotating table.
+	go func() {
+		for err := range table.BackgroundErrors() {
+			log.Fatal(err)
+		}
+	}()
+
+	latencies := make(chan time.Duration, 1)
+
+	// Every second, print out the largest latency
+	// of any one request over that second.
+	go func() {
+		t := time.NewTicker(1 * time.Second)
+		var maxL time.Duration
+		for {
+			select {
+			case <-t.C:
+				log.Printf("Max latency over 1s: %v", maxL)
+				maxL = 0
+			case l := <-latencies:
+				if l > maxL {
+					maxL = l
+				}
+			}
+		}
+	}()
+
+	for {
+		start := time.Now()
+		_, err := table.ReadRow(context.Background(), rowKey)
+		latencies <- time.Since(start)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Add an example of how a user could automatically refresh their Cloud Bigtable connections without hitting the automatic connection reset.