### PR TITLE
[spark-wordcount] Update versions and code (RDD)

### DIFF
--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -104,7 +104,7 @@
                     </descriptorRefs>
                     <archive>
                         <manifest>
-                            <mainClass>WordCount</mainClass>
+                            <mainClass>com.example.bigtable.spark.wordcount.WordCount</mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <name>cloud-bigtable-dataproc-spark-wordcount</name>
@@ -11,10 +13,10 @@
     <properties>
         <bigtable.version>1.15.0</bigtable.version>
         <hbase.version>1.6.0</hbase.version>
-        <hadoop.version>2.8.5</hadoop.version>
+        <hadoop.version>2.10.0</hadoop.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <spark.version>2.4.6</spark.version>
+        <spark.version>2.4.5</spark.version>
         <scala.version>2.11.12</scala.version>
         <scalatest.version>3.0.3</scalatest.version>
         <skipTests>true</skipTests>
@@ -36,6 +38,7 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -10,6 +10,9 @@
     <packaging>jar</packaging>
     <version>0.1</version>
 
+    <!--
+       - hbase, hadoop, spark, scala versions follow Dataproc 1.5.x
+       -->
     <properties>
         <bigtable.version>1.15.0</bigtable.version>
         <hbase.version>1.5.0</hbase.version>
@@ -18,6 +21,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <spark.version>2.4.5</spark.version>
         <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
         <scalatest.version>3.0.3</scalatest.version>
         <skipTests>true</skipTests>
     </properties>
@@ -25,7 +29,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -64,13 +68,13 @@
         </dependency>
         <dependency>
             <groupId>org.scalactic</groupId>
-            <artifactId>scalactic_2.11</artifactId>
+            <artifactId>scalactic_${scala.binary.version}</artifactId>
             <version>${scalatest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>${scalatest.version}</version>
             <scope>test</scope>
         </dependency>

--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -9,11 +9,11 @@
     <version>0.1</version>
 
     <properties>
-        <bigtable.version>1.7.0</bigtable.version>
-        <hbase.version>1.3.1</hbase.version>
+        <bigtable.version>1.15.0</bigtable.version>
+        <hbase.version>1.6.0</hbase.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <spark.version>2.4.0</spark.version>
+        <spark.version>2.4.6</spark.version>
         <scala.version>2.11.12</scala.version>
         <scalatest.version>3.0.3</scalatest.version>
         <skipTests>true</skipTests>
@@ -30,7 +30,6 @@
             <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
             <version>${bigtable.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-server</artifactId>
@@ -41,23 +40,22 @@
             <artifactId>hbase-client</artifactId>
             <version>${hbase.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
         </dependency>
-
-        <!-- test dependencies -->
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
-            <version>1.9</version>
+            <version>1.10</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalactic</groupId>
             <artifactId>scalactic_2.11</artifactId>
             <version>${scalatest.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <bigtable.version>1.15.0</bigtable.version>
-        <hbase.version>1.6.0</hbase.version>
+        <hbase.version>1.5.0</hbase.version>
         <hadoop.version>2.10.0</hadoop.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -25,6 +25,7 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
             <version>${spark.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigtable</groupId>
@@ -50,6 +51,7 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>

--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -11,7 +11,8 @@
     <version>0.1</version>
 
     <!--
-       - hbase, hadoop, spark, scala versions follow Dataproc 1.5.x
+       - hbase, hadoop, spark versions follow Dataproc 1.5.x
+       - Spark 2.x is pre-built with Scala 2.11
        -->
     <properties>
         <bigtable.version>1.15.0</bigtable.version>

--- a/scala/spark-wordcount/pom.xml
+++ b/scala/spark-wordcount/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <bigtable.version>1.15.0</bigtable.version>
         <hbase.version>1.6.0</hbase.version>
+        <hadoop.version>2.8.5</hadoop.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <spark.version>2.4.6</spark.version>
@@ -29,6 +30,11 @@
             <groupId>com.google.cloud.bigtable</groupId>
             <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
             <version>${bigtable.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/scala/spark-wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
+++ b/scala/spark-wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
@@ -151,12 +151,13 @@ object WordCount {
     val WordCountTableName = args(2)
     val File = args(3)
 
-    // There seems to be a bug in HBase 1.6.0
-    // See https://stackoverflow.com/a/51959451/1305344
-    // Read https://spark.apache.org/docs/2.4.6/configuration.html#execution-behavior
     import org.apache.spark.SparkConf
     val sparkConf = new SparkConf()
-      .set("spark.hadoop.validateOutputSpecs", "false")
+
+    // Workaround for a bug in TableOutputFormat in HBase 1.6.0
+    // See https://stackoverflow.com/a/51959451/1305344
+    sparkConf.set("spark.hadoop.validateOutputSpecs", "false")
+
     val sc = new SparkContext(sparkConf)
 
     runner(ProjectId, InstanceID, WordCountTableName, File, sc)

--- a/scala/spark-wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
+++ b/scala/spark-wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
@@ -129,7 +129,7 @@ object WordCount {
 
     val wordCounts = sc
       .textFile(fileName)
-      .flatMap(_.split("\\s+"))
+      .flatMap(_.split("\\W+"))
       .filter(!_.isEmpty)
       .map { word => (word, 1) }
       .reduceByKey(_ + _)

--- a/scala/spark-wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
+++ b/scala/spark-wordcount/src/main/scala/com/example/bigtable/spark/wordcount/WordCount.scala
@@ -136,6 +136,8 @@ object WordCount {
       .map { case (word, count) =>
         val put = new Put(Bytes.toBytes(word))
           .addColumn(ColumnFamilyBytes, ColumnNameBytes, Bytes.toBytes(count))
+        // The underlying writer ignores keys, only the value matter here.
+        // https://github.com/apache/hbase/blob/1b9269/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableOutputFormat.java#L138-L145
         (null, put)
       }
     wordCounts.saveAsNewAPIHadoopDataset(conf)

--- a/scala/spark-wordcount/src/test/scala/com/example/bigtable/spark/wordcount/SparkSpec.scala
+++ b/scala/spark-wordcount/src/test/scala/com/example/bigtable/spark/wordcount/SparkSpec.scala
@@ -35,6 +35,9 @@ trait SparkSpec extends BeforeAndAfterAll {
     val conf = new SparkConf()
       .setMaster("local[*]")
       .setAppName(this.getClass.getSimpleName)
+    // Workaround for a bug in TableOutputFormat in HBase 1.6.0
+    // See https://stackoverflow.com/a/51959451/1305344
+    conf.set("spark.hadoop.validateOutputSpecs", "false")
 
     sparkConfig.foreach { case (k, v) => conf.setIfMissing(k, v) }
 

--- a/scala/spark-wordcount/src/test/scala/com/example/bigtable/spark/wordcount/WordCountIT.scala
+++ b/scala/spark-wordcount/src/test/scala/com/example/bigtable/spark/wordcount/WordCountIT.scala
@@ -82,6 +82,6 @@ class WordCountIT extends FlatSpec with BeforeAndAfterEach with BeforeAndAfterAl
       count += 1
       rs = scanner.next
     }
-    count should equal(162)
+    count should equal(139)
   }
 }


### PR DESCRIPTION
- Use the latest versions of Bigtable and HBase for 1.x release line matching Dataproc's
- Spark 2.4.5 (Scala 2.11)
- Code cleanup for better readability (hopefully)

Changes tested with [Cloud Bigtable Emulator](https://cloud.google.com/bigtable/docs/emulator) and using `mvn test -DskipTests=false`