### PR TITLE
dataflow-connector-examples: upgrade Apache Beam

### DIFF
--- a/java/dataflow-connector-examples/pom.xml
+++ b/java/dataflow-connector-examples/pom.xml
@@ -46,7 +46,7 @@ limitations under the License.
   -->
 
   <properties>
-    <beam.version>2.4.0</beam.version>
+    <beam.version>2.24.0</beam.version>
     <bigtable.version>1.4.0</bigtable.version>
     <slf4j.version>1.7.21</slf4j.version>
 


### PR DESCRIPTION
pom dependency to latest 2.24.0 from 2.4.0 to fix the following error.

```
[main] INFO org.apache.beam.runners.dataflow.DataflowRunner - Staging pipeline description to gs://dataflow-staging-us-central1-657748983213/temp/staging/
Dataflow SDK version: 2.4.0
[main] WARN org.apache.beam.sdk.util.RetryHttpRequestInitializer - Request failed with code 400, performed 0 retries due to IOExceptions, performed 0 retries due to unsuccessful status codes, HTTP framework says request can be retried, (caller responsible for retrying): https://dataflow.googleapis.com/v1b3/projects/my-project/locations/us-central1/jobs
Exception in thread "main" java.lang.RuntimeException: Failed to create a workflow job: (8eace89709577964): The workflow was automatically rejected by the service because it uses an unsupported SDK Apache Beam SDK for Java 2.4.0. Please upgrade to the latest SDK version. To override the SDK version check temporarily, please provide an override token using the experiment flag '--experiments=unsupported_sdk_temporary_override_token=2020-10-28T17:56:06-07:00:[TOKEN]'. Note that this token expires on 2020-10-28T17:56:06-07:00.
For a list of supported SDK versions, see:
https://cloud.google.com/dataflow/support#support-status-for-dataflow-sdk-releases
Details about token use can be found at https://cloud.google.com/dataflow/docs/support/using-unsupported-sdks.
	at org.apache.beam.runners.dataflow.DataflowRunner.run(DataflowRunner.java:787)
	at org.apache.beam.runners.dataflow.DataflowRunner.run(DataflowRunner.java:174)
	at org.apache.beam.sdk.Pipeline.run(Pipeline.java:311)
	at org.apache.beam.sdk.Pipeline.run(Pipeline.java:297)
	at com.google.cloud.bigtable.dataflow.example.CsvImport.main(CsvImport.java:151)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "(8eace89709577964): The workflow was automatically rejected by the service because it uses an unsupported SDK Apache Beam SDK for Java 2.4.0. Please upgrade to the latest SDK version. To override the SDK version check temporarily, please provide an override token using the experiment flag '--experiments=unsupported_sdk_temporary_override_token=2020-10-28T17:56:06-07:00:[TOKEN]'. Note that this token expires on 2020-10-28T17:56:06-07:00.\nFor a list of supported SDK versions, see:\nhttps://cloud.google.com/dataflow/support#support-status-for-dataflow-sdk-releases \nDetails about token use can be found at https://cloud.google.com/dataflow/docs/support/using-unsupported-sdks.",
    "reason" : "failedPrecondition"
  } ],
  "message" : "(8eace89709577964): The workflow was automatically rejected by the service because it uses an unsupported SDK Apache Beam SDK for Java 2.4.0. Please upgrade to the latest SDK version. To override the SDK version check temporarily, please provide an override token using the experiment flag '--experiments=unsupported_sdk_temporary_override_token=2020-10-28T17:56:06-07:00:[TOKEN]'. Note that this token expires on 2020-10-28T17:56:06-07:00.\nFor a list of supported SDK versions, see:\nhttps://cloud.google.com/dataflow/support#support-status-for-dataflow-sdk-releases \nDetails about token use can be found at https://cloud.google.com/dataflow/docs/support/using-unsupported-sdks.",
  "status" : "FAILED_PRECONDITION"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:321)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1065)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:419)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:469)
	at org.apache.beam.runners.dataflow.DataflowClient.createJob(DataflowClient.java:61)
	at org.apache.beam.runners.dataflow.DataflowRunner.run(DataflowRunner.java:774)
	... 4 more
```