### PR TITLE
chore: add renovate config and CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# The @googleapis/api-bigtable is the default owner for changes in this repo
+*                       @googleapis/api-bigtable

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "extends": [
+    ":separateMajorReleases",
+    ":combinePatchMinorReleases",
+    ":ignoreUnstable",
+    ":prImmediately",
+    ":updateNotScheduled",
+    ":automergeDisabled",
+    ":ignoreModulesAndTests",
+    ":maintainLockFilesDisabled",
+    ":autodetectPinVersions"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "enabled": "false"
+    }
+  ],
+  "semanticCommits": true,
+  "dependencyDashboard": true
+}


### PR DESCRIPTION
Fixes #355 

Note: renovate will be turned off to not flood the incoming upgrades